### PR TITLE
Add support for chained dependencies

### DIFF
--- a/R/generateDesign.R
+++ b/R/generateDesign.R
@@ -43,6 +43,8 @@
 #' with complicated dependences and forbidden regions, if one wants to ensure that points actually
 #' get added... But we are working on it,
 #'
+#' generateDesign will NOT work if there are dependencies over multiple levels of parameters and the dependency is only given with respect to the previous parameter.
+#'
 #' @template arg_gendes_n
 #' @template arg_parset
 #' @param fun [\code{function}]\cr

--- a/R/isFeasible.R
+++ b/R/isFeasible.R
@@ -131,5 +131,9 @@ constraintsOkLearnerParam = function(par, x) {
 # is the requires part of the ith param valid for value x (x[[i]] is value or ith param)
 # assumes that param actually has a requires part
 requiresOk = function(par.set, x, i) {
-  eval(par.set$pars[[i]]$requires, envir = x)
+  if (is.null(par.set$pars[[i]]$requires)) {
+    TRUE
+  } else {
+    isTRUE(eval(par.set$pars[[i]]$requires, envir = x))
+  }
 }

--- a/R/isRequiresOk.R
+++ b/R/isRequiresOk.R
@@ -28,8 +28,7 @@ isRequiresOk = function(par.set, par.vals, ids = names(par.vals), use.defaults =
     par.vals.env = par.vals
   }
   requireOks = vlapply(names(par.vals), function(par.name) {
-    res = requiresOk(par.set, par.vals.env, par.name)
-    is.null(res) || res
+    requiresOk(par.set, par.vals.env, par.name)
   })
   if (any(!requireOks)) {
     #just constructing an informative error message

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -162,6 +162,18 @@ test_that("requires works", {
   expect_error(isRequiresOk(ps, list(y = 1, x = "b")), 'x == "a"')
 })
 
+test_that("requires chains work", {
+  ps = makeParamSet(
+    makeLogicalLearnerParam("a", default = FALSE),
+    makeLogicalLearnerParam("b", default = FALSE, requires = quote(a == TRUE)),
+    makeLogicalLearnerParam("c", default = FALSE, requires = quote(b == TRUE))
+  )
+  expect_true(isFeasible(ps, list(a = FALSE, b = NA, c = NA)))
+  expect_true(isFeasible(ps, list(a = TRUE, b = FALSE, c = NA)))
+  expect_true(isFeasible(ps, list(a = TRUE, b = TRUE, c = FALSE)))
+  expect_true(isFeasible(ps, list(a = TRUE, b = TRUE, c = TRUE)))
+})
+
 test_that("print works", {
   ps = makeParamSet(
     makeIntegerParam("ntree", lower = 10, upper = 50),

--- a/tests/testthat/test_generateDesign.R
+++ b/tests/testthat/test_generateDesign.R
@@ -179,6 +179,20 @@ test_that("nested requires", {
   expect_true(all(oks))
 })
 
+test_that("requires chains work", {
+  ps8 = makeParamSet(
+    makeLogicalLearnerParam("a", default = FALSE),
+    makeLogicalLearnerParam("b", default = FALSE, requires = quote(a == TRUE)),
+    # FIXME: shouldn't need to make the chain explicit
+    makeLogicalLearnerParam("c", default = FALSE, requires = quote(b == TRUE && a == TRUE))
+  )
+  des = generateDesign(10, par.set = ps8)
+  vals = dfRowsToList(des, ps8)
+  oks = sapply(vals, isFeasible, par = ps8)
+  expect_true(all(oks))
+})
+
+
 test_that("we dont drop levels in factors", {
   ps = makeParamSet(
     makeDiscreteParam("x", values = letters[1:5])


### PR DESCRIPTION
See new test -- this failed before with error message `Error in if (!requiresOk(par, x, i)) { :
  missing value where TRUE/FALSE needed`.

This required changing the implementation of `isRequiresOk`, which was calling `requiresOk` with parameters that didn't have any requirements. This is now checked explicitly and the function only called if there are requires.