### PR TITLE
generateRandomDesign keeps factor order and cleanup of generateDesign

### DIFF
--- a/R/generateGridDesign.R
+++ b/R/generateGridDesign.R
@@ -11,10 +11,11 @@
 #' If you want to convert these, look at \code{\link[BBmisc]{convertDataFrameCols}}.
 #' Dependent parameters whose constraints are unsatisfied generate \code{NA} entries in their
 #' respective columns.
+#' For discrete vectors the levels and their order will be preserved.
 #'
 #' The algorithm currently performs these steps:
 #' \enumerate{
-#'   \item{We create a grid. For numerics and integers we use the specfied resolution.}
+#'   \item{We create a grid. For numerics and integers we use the specfied resolution. For discretes all values will be taken.}
 #'   \item{Forbidden points are removed.}
 #'   \item{Parameters are trafoed (maybe); dependent parameters whose constraints are unsatisfied
 #'     are set to \code{NA} entries.}
@@ -134,6 +135,10 @@ generateGridDesign = function(par.set, resolution, trafo = FALSE) {
   res = res[!duplicated(res), , drop = FALSE]
 
   res = convertDataFrameCols(res, chars.as.factor = TRUE)
+
+  #fix factors
+  res = fixDesignFactors(res, par.set)
+
   attr(res, "trafo") = trafo
   return(res)
 }

--- a/R/generateRandomDesign.R
+++ b/R/generateRandomDesign.R
@@ -11,6 +11,7 @@
 #' If you want to convert these, look at \code{\link[BBmisc]{convertDataFrameCols}}.
 #' Dependent parameters whose constraints are unsatisfied generate \code{NA} entries in their
 #' respective columns.
+#' For discrete vectors the levels and their order will be preserved, even if not all levels are present.
 #'
 #' The algorithm simply calls \code{\link{sampleValues}} and arranges the result in a data.frame.
 #'
@@ -26,8 +27,6 @@
 #' @export
 generateRandomDesign = function(n = 10L, par.set, trafo = FALSE) {
   z = doBasicGenDesignChecks(par.set)
-  pids = getParamIds(par.set, repeated = TRUE, with.nr = TRUE)
-
   des = sampleValues(par.set, n, discrete.names = TRUE, trafo = trafo)
 
   # FIXME: all next lines are sloooow in R I guess. C?
@@ -43,7 +42,10 @@ generateRandomDesign = function(n = 10L, par.set, trafo = FALSE) {
   des = lapply(des, elementsToDf)
   des = lapply(des, do.call, what = cbind)
   des = do.call(rbind, des)
-  return(setColNames(des, pids))
+  colnames(des) = getParamIds(par.set, repeated = TRUE, with.nr = TRUE)
+  des  = fixDesignFactors(des, par.set)
+  attr(des, "trafo") = trafo
+  return(des)
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -45,3 +45,23 @@ getParamNA = function(par, repeated = FALSE) {
     v = rep(v, par$len)
   return(v)
 }
+
+# Create a list with the values from getValues, but respect vector parameters and
+# create a single list item for each vector component named paramId.number
+getParamSetValues = function(par.set) {
+  pids1 = getParamIds(par.set, repeated = TRUE, with.nr = TRUE)
+  pids2 = getParamIds(par.set, repeated = TRUE, with.nr = FALSE)
+  values1 = getValues(par.set)
+  values2 = lapply(pids2, function(x) {names(values1[[x]])})
+  setNames(values2, pids1)
+}
+
+# Makes sure we keep all levels of a discrete vector and also keep them in order.
+fixDesignFactors = function(des, par.set) {
+  types.df = getParamTypes(par.set, df.cols = TRUE)
+  values = getParamSetValues(par.set)
+  for (i in which(types.df == "factor")) {
+    des[, i] = factor(des[, i], levels = values[[colnames(des)[i]]])
+  }
+  des
+}

--- a/man/generateDesign.Rd
+++ b/man/generateDesign.Rd
@@ -56,6 +56,7 @@ The following types of columns are created:
 If you want to convert these, look at \code{\link[BBmisc]{convertDataFrameCols}}.
 Dependent parameters whose constraints are unsatisfied generate \code{NA} entries in their
 respective columns.
+For discrete vectors the levels and their order will be preserved, even if not all levels are present.
 
 Currently only lhs designs are supported.
 

--- a/man/generateGridDesign.Rd
+++ b/man/generateGridDesign.Rd
@@ -37,10 +37,11 @@ The following types of columns are created:
 If you want to convert these, look at \code{\link[BBmisc]{convertDataFrameCols}}.
 Dependent parameters whose constraints are unsatisfied generate \code{NA} entries in their
 respective columns.
+For discrete vectors the levels and their order will be preserved.
 
 The algorithm currently performs these steps:
 \enumerate{
-  \item{We create a grid. For numerics and integers we use the specfied resolution.}
+  \item{We create a grid. For numerics and integers we use the specfied resolution. For discretes all values will be taken.}
   \item{Forbidden points are removed.}
   \item{Parameters are trafoed (maybe); dependent parameters whose constraints are unsatisfied
     are set to \code{NA} entries.}

--- a/man/generateRandomDesign.Rd
+++ b/man/generateRandomDesign.Rd
@@ -36,6 +36,7 @@ The following types of columns are created:
 If you want to convert these, look at \code{\link[BBmisc]{convertDataFrameCols}}.
 Dependent parameters whose constraints are unsatisfied generate \code{NA} entries in their
 respective columns.
+For discrete vectors the levels and their order will be preserved, even if not all levels are present.
 
 The algorithm simply calls \code{\link{sampleValues}} and arranges the result in a data.frame.
 

--- a/tests/testthat/test_generateDesign.R
+++ b/tests/testthat/test_generateDesign.R
@@ -54,6 +54,7 @@ test_that("simple num/int/discrete/log design", {
   expect_true(des[,2] >= 10 && des[,2] <= 20)
   expect_true(is.factor(des[,3]))
   expect_true(all(des[,3] %in% names(ps3$pars[[3]]$values)))
+  expect_equal(levels(des[,3]), names(ps3$pars[[3]]$values))
   expect_true(is.logical(des[,4]))
   tab = as.numeric(table(des[,3]))
   expect_true(all(tab > 140 & tab < 180))
@@ -88,6 +89,8 @@ test_that("num/int/disc vec design", {
   expect_true(des[,5] >= 10 && des[,5] <= 20)
   expect_true(all(des[,6] %in% c("a", "b")))
   expect_true(all(des[,7] %in% c("a", "b")))
+  expect_equal(levels(des[,6]), c("a", "b"))
+  expect_equal(levels(des[,7]), c("a", "b"))
 })
 
 test_that("num/int vec design with trafo", {
@@ -194,10 +197,10 @@ test_that("requires chains work", {
 
 test_that("we dont drop levels in factors", {
   ps = makeParamSet(
-    makeDiscreteParam("x", values = letters[1:5])
+    makeDiscreteParam("x", values = letters[5:1])
   )
   des = generateDesign(1, ps)
-  expect_true(is.factor(des$x) && levels(des$x) == letters[1:5])
+  expect_true(is.factor(des$x) && levels(des$x) == letters[5:1])
 })
 
 test_that("list of further arguments passed to lhs function produces no error", {

--- a/tests/testthat/test_generateGridDesign.R
+++ b/tests/testthat/test_generateGridDesign.R
@@ -110,7 +110,7 @@ test_that("nested requires", {
 
 test_that("discrete works without resolution", {
   ps8 = makeParamSet(
-    makeDiscreteParam("disc", values = c("a", "b", "c")),
+    makeDiscreteParam("disc", values = c("c", "b", "a")),
     makeDiscreteParam("discA", values = c("m", "w"), requires = quote(disc == "a")),
     makeLogicalParam("logA")
     )
@@ -118,7 +118,6 @@ test_that("discrete works without resolution", {
   expect_true(nrow(des) == 8)
   expect_true(all(is.na(des[des$disc == "c", "discA"])))
   expect_true(all(is.na(des[des$disc == "b", "discA"])))
+  expect_equal(levels(des[,2]), c("m", "w"))
+  expect_equal(levels(des[,1]), c("c", "b", "a"))
 })
-
-
-

--- a/tests/testthat/test_generateRandomDesign.R
+++ b/tests/testthat/test_generateRandomDesign.R
@@ -25,6 +25,8 @@ test_that("num/int/disc vec design", {
   expect_true(des[,4] >= 10 && des[,4] <= 20)
   expect_true(all(des[,5] %in% c("a", "b")))
   expect_true(all(des[,6] %in% c("a", "b")))
+  expect_equal(levels(des[,5]), c("a", "b"))
+  expect_equal(levels(des[,6]), c("a", "b"))
 })
 
 test_that("requires works", {
@@ -47,3 +49,10 @@ test_that("requires works", {
   expect_true(all(oks))
 })
 
+test_that("we dont drop levels in factors", {
+  ps = makeParamSet(
+    makeDiscreteParam("x", values = letters[5:1])
+  )
+  des = generateRandomDesign(1, ps)
+  expect_true(is.factor(des$x) && levels(des$x) == letters[5:1])
+})


### PR DESCRIPTION
It could happen that generateRandomDesign mixed up the orders of the factors. This is now fixed. In the process I also cleaned generateDesign a tiny bit.
I introduced the unexported function getParamSetValues as a helper.