### PR TITLE
Fix #83: Repaired convertParamSetToIrace for long requirements

### DIFF
--- a/R/convertParamSetToIrace.R
+++ b/R/convertParamSetToIrace.R
@@ -47,7 +47,7 @@ convertParamSetToIrace = function(par.set, as.chars = FALSE) {
         stopf("Unknown parameter type: %s", p$type)
       }
       if (!is.null(p$requires)) {
-        line = paste(line, capture.output(p$requires), sep = " | ")
+        line = paste(line, collapse(capture.output(p$requires), sep=""), sep = " | ")
       }
       lines[count] = line
       count = count + 1L

--- a/tests/testthat/test_convertParamSetToIrace.R
+++ b/tests/testthat/test_convertParamSetToIrace.R
@@ -32,7 +32,9 @@ test_that("convertParamSetToIrace", {
   runIrace(ps, hook.run, max.exps = 300)
   ps = makeParamSet(
     makeDiscreteParam("x1", values = c("a", "b")),
-    makeLogicalParam("x2", requires = quote(x1 == "a"))
+    makeLogicalParam("x2", requires = quote(x1 == "a")),
+    makeLogicalParam("x3", requires =
+      quote(x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE"))
   )
   ips = convertParamSetToIrace(ps)
   expect_false(identical(ips$constraints$x2, expression(TRUE)))
@@ -40,6 +42,8 @@ test_that("convertParamSetToIrace", {
     v = experiment$candidate
     if ((v$x1 == "a" && is.na(v$x2)) || (v$x1 == "b" && !is.na(v$x2)))
       stop("foo")
+    if ((v$x1 == "a" && v$x2 == "FALSE" && is.na(v$x3)) || (!(v$x1 == "a" && v$x2 == "FALSE") && !is.na(v$x3)))
+      stop("requires failed")
     1
   }
   runIrace(ps, hook.run, max.exps = 300)


### PR DESCRIPTION
Fix #83 (deparse sometimes returns nonscalar values, see issue for more info).