### PR TITLE
Dot extras

### DIFF
--- a/R/OptPath.R
+++ b/R/OptPath.R
@@ -126,8 +126,11 @@ print.OptPath = function(x, ...) {
     s = sprintf(" Range: %g - %g. %i NAs.", et1, et2, ntime.nas)
   }
   catf("  Exec times: %s.%s", !is.null(et), s)
-  if (!is.null(ex))
-  catf("  Extras: %i columns", ifelse(length(ex) > 0L, length(ex[[1]]), NA))
+  if (!is.null(ex)) {
+    nondot.extra.length = ifelse(length(ex) > 0L,
+        length(removeDotEntries(ex[[1]])), NA)
+    catf("  Extras: %i columns", nondot.extra.length)
+  }
 }
 
 

--- a/R/OptPathDF_as_data_frame.R
+++ b/R/OptPathDF_as_data_frame.R
@@ -75,9 +75,10 @@ as.data.frame.OptPathDF = function(x, row.names = NULL, optional = FALSE,
       res$error.message = x$env$error.message[ind]
     if (!is.null(x$env$exec.time))
       res$exec.time = x$env$exec.time[ind]
-    if (!is.null(x$env$extra))
-      extraclean = lapply(x$env$extra[ind], removeDotEntries)
-      res = cbind(res, convertListOfRowsToDataFrame(extraclean))
+    if (!is.null(x$env$extra)) {
+      extra.clean = lapply(x$env$extra[ind], removeDotEntries)
+      res = cbind(res, convertListOfRowsToDataFrame(extra.clean))
+    }
   }
   if (!is.null(row.names)) {
     assertCharacter(row.names, len = nrow(res), any.missing = FALSE)

--- a/R/OptPathDF_as_data_frame.R
+++ b/R/OptPathDF_as_data_frame.R
@@ -76,13 +76,20 @@ as.data.frame.OptPathDF = function(x, row.names = NULL, optional = FALSE,
     if (!is.null(x$env$exec.time))
       res$exec.time = x$env$exec.time[ind]
     if (!is.null(x$env$extra))
-      res = cbind(res, convertListOfRowsToDataFrame(x$env$extra[ind]))
+      extraclean = lapply(x$env$extra[ind], removeDotEntries)
+      res = cbind(res, convertListOfRowsToDataFrame(extraclean))
   }
   if (!is.null(row.names)) {
     assertCharacter(row.names, len = nrow(res), any.missing = FALSE)
     rownames(res) = row.names
   }
   return(res)
+}
+
+# remove all named entries that have a name starting with a dot
+removeDotEntries = function(l) {
+  l[grep("^\\.", names(l))] = NULL
+  l
 }
 
 

--- a/R/OptPathDF_getter.R
+++ b/R/OptPathDF_getter.R
@@ -85,8 +85,9 @@ getOptPathCol.OptPathDF = function(op, name, dob = op$env$dob, eol = op$env$eol)
     return(getOptPathExecTimes(op, dob, eol))
   if (name == "error.message")
     return(getOptPathErrorMessages(op, dob, eol))
-  if (name %in% names(op$env$extra[[1]]))
-    return(extractSubList(op$env$extra[getOptPathDobAndEolIndex(op, dob, eol)], name))
+  if (name %in% names(op$env$extra[[1]]) || substr(name, 1, 1) == ".")
+    return(extractSubList(op$env$extra[getOptPathDobAndEolIndex(op, dob, eol)], name,
+            simplify = substr(name, 1, 1) != "."))
   stop("The column you specified is not present in the opt.path.")
 }
 

--- a/R/OptPathDF_setter.R
+++ b/R/OptPathDF_setter.R
@@ -16,13 +16,17 @@ addOptPathEl.OptPathDF = function(op, x, y, dob = getOptPathLength(op)+1L, eol =
     assertList(extra)
     if (!isProperlyNamed(extra))
       stopf("'extra' must be properly named!")
-    if (!all(sapply(extra, isScalarValue)))
+    nondot.extra = removeDotEntries(extra)
+    if (!all(sapply(nondot.extra, isScalarValue)))
       stopf("'extra' can currently only contain scalar values!")
     if (length(env$extra) > 0L) {
-      if (!all(names(extra) %in% names(env$extra[[1L]])))
-        stopf("Trying to add unknown extra(s): %s!", collapse(setdiff(names(extra), names(env$extra[[1L]]))))
-      if (!all(names(env$extra[[1L]]) %in% (names(extra))))
-        stopf("Trying to add extras but missing: %s!", collapse(setdiff(names(env$extra[[1L]]), names(extra))))
+      nondot.extra.precedent = removeDotEntries(env$extra[[1L]])
+      unknown.extra = setdiff(names(nondot.extra), names(nondot.extra.precedent))
+      missing.extra = setdiff(names(nondot.extra.precedent), names(nondot.extra))
+      if (length(unknown.extra) > 0)
+        stopf("Trying to add unknown extra(s): %s!", collapse(unknown.extra))
+      if (length(missing.extra) > 0)
+        stopf("Trying to add extras but missing: %s!", collapse(missing.extra))
     }
     env$extra[[length(env$extra) + 1L]] = extra
   }

--- a/R/OptPath_setter.R
+++ b/R/OptPath_setter.R
@@ -65,8 +65,10 @@ setOptPathElEOL = function(op, index, eol) {
 #'   Default is \code{NA}.
 #' @param extra [\code{list}]\cr
 #'   Possible list of extra values to store.
-#'   The list must be fully named, can currently only contain scalar values and must always
-#'   be in the same order of all calls of \code{addOptPathEl}.
+#'   The list must be fully named. The list can contain nonscalar values, but
+#'   these nonscalar entries must have a name starting with a dot (\code{.}).
+#'   Other entries must be scalar, and must be in the same order of all calls of
+#'   \code{addOptPathEl}.
 #'   Default is \code{NULL}
 #' @param check.feasible [\code{logical(1)}]\cr
 #'   Should \code{x} be checked with \code{\link{isFeasible}}?

--- a/man/addOptPathEl.Rd
+++ b/man/addOptPathEl.Rd
@@ -37,8 +37,10 @@ Default is \code{NA}.}
 
 \item{extra}{[\code{list}]\cr
 Possible list of extra values to store.
-The list must be fully named, can currently only contain scalar values and must always
-be in the same order of all calls of \code{addOptPathEl}.
+The list must be fully named. The list can contain nonscalar values, but
+these nonscalar entries must have a name starting with a dot (\code{.}).
+Other entries must be scalar, and must be in the same order of all calls of
+\code{addOptPathEl}.
 Default is \code{NULL}}
 
 \item{check.feasible}{[\code{logical(1)}]\cr

--- a/tests/testthat/test_OptPath.R
+++ b/tests/testthat/test_OptPath.R
@@ -335,4 +335,9 @@ test_that("opt.path printing works", {
   expect_output(print(op), "Exec times: TRUE. Range: 0 - 0. 1 NAs")
   addOptPathEl(op, x = list(x = 1, y = "a"), y = c(z1 = 1), exec.time = 3)
   expect_output(print(op), "Exec times: TRUE. Range: 3 - 3. 1 NAs.")
+
+  op = makeOptPathDF(par.set = ps, y.names = c("z1", "z2"), minimize = c(TRUE, FALSE), include.extra = TRUE)
+  expect_output(print(op), "Extras: NA columns")
+  addOptPathEl(op, x = list(x = 1, y = "a"), y = c(z1 = 1, z2 = 4), extra = list(ee = 8, .ee = list(a = 1, b = 2)))
+  expect_output(print(op), "Extras: 1 columns")
 })

--- a/tests/testthat/test_OptPath.R
+++ b/tests/testthat/test_OptPath.R
@@ -255,14 +255,27 @@ test_that("logging extra works", {
   expect_error(addOptPathEl(op, x = list(v = 1), y = 5, extra = list()), "Trying to add extras but missing: ee")
 })
 
+test_that("exta entries with dots may be nonscalar", {
+  ps = makeParamSet(makeNumericParam("v"))
+  op = makeOptPathDF(par.set = ps, y.names = "y", minimize = TRUE, include.extra = TRUE)
+  addOptPathEl(op, x = list(v = 1), y = 5, extra = list(ee = 7, .ee = list(1, list())))
+  df = setRowNames(as.data.frame(op), NULL)
+  expect_equal(df, data.frame(v = 1, y = 5, dob = 1L, eol = NA_integer_, ee = 7))
+  expect_equal(getOptPathEl(op, 1L), list(x = list(v = 1), y = c(y = 5), dob = 1L, eol = NA_integer_,
+    extra = list(ee = 7, .ee = list(1, list()))))
+  # adding dotted extras with different names should be allowed
+  addOptPathEl(op, x = list(v = 1), y = 5, extra = list(ee = 8, .ff = 1))
+  addOptPathEl(op, x = list(v = 1), y = 5, extra = list(ee = 9))
+})
+
 test_that("as.data.frame flags and getCols works", {
   ps = makeParamSet(
     makeNumericParam("x"),
     makeDiscreteParam("y", values = c("a", "b"))
   )
   op = makeOptPathDF(par.set = ps, y.names = c("z1", "z2"), minimize = c(TRUE, TRUE), include.extra = TRUE)
-  addOptPathEl(op, x = list(x = 1, y = "a"), y = c(z1 = 1, z2 = 4), extra = list(ee = 7))
-  addOptPathEl(op, x = list(x = 2, y = "a"), y = c(z1 = 3, z2 = 2), extra = list(ee = 8))
+  addOptPathEl(op, x = list(x = 1, y = "a"), y = c(z1 = 1, z2 = 4), extra = list(ee = 7, .ee = 8))
+  addOptPathEl(op, x = list(x = 2, y = "a"), y = c(z1 = 3, z2 = 2), extra = list(ee = 8, .ff = list(8, list())))
 
   expect_error(as.data.frame(op, include.x = FALSE, include.y = FALSE, include.rest = FALSE), "include something")
   df1 = as.data.frame(op, include.rest = FALSE, discretes.as.factor = TRUE)
@@ -279,6 +292,7 @@ test_that("as.data.frame flags and getCols works", {
   expect_equal(sapply(df1, class), c(x = "numeric", y = "factor", z1 = "numeric", z2 = "numeric"))
   expect_equal(sapply(df2, class), c(z1 = "numeric", z2 = "numeric"))
   expect_equal(sapply(df3, class), c(dob = "integer", eol = "integer", ee = "numeric"))
+  # the dotted entries are not present as columns.
   expect_equal(sapply(df4, class), c(x = "numeric", y = "factor", z1 = "numeric", z2 = "numeric",
     dob = "integer", eol = "integer", ee = "numeric"))
   expect_error(getOptPathCol(op,"bla"), "not present")

--- a/tests/testthat/test_OptPath.R
+++ b/tests/testthat/test_OptPath.R
@@ -304,6 +304,9 @@ test_that("as.data.frame flags and getCols works", {
   expect_equal(getOptPathCol(op, "y"), c("a", "a"))
   expect_equal(getOptPathCol(op, "z1"), c(1, 3))
   expect_equal(getOptPathCol(op, "ee"), c(7, 8))
+  expect_equal(getOptPathCol(op, ".ee"), list(8, NULL))
+  expect_equal(getOptPathCol(op, ".ff"), list(NULL, list(8, list())))
+  expect_equal(getOptPathCol(op, ".xx"), list(NULL, NULL))
 
   d = getOptPathCols(op, c("x", "y"))
   expect_equal(dim(d), c(2L, 2L))


### PR DESCRIPTION
Address #97: It is now possible to store nonscalar values in the `extra` field of an `OptPathDF`, as long as these elements have names starting with a dot ("`.`"). These elements are not part of the object generated by `as.data.frame`, their presence or absence is not checked by `addOptPathEl` (since absence is usually treated similarly to `NULL` in nonscalar objects), and `getOptPathCol` returns a list (instead of a vector) for column names starting with a dot.