### PR TITLE
use deparse instead of capture.output

### DIFF
--- a/R/convertParamSetToIrace.R
+++ b/R/convertParamSetToIrace.R
@@ -47,7 +47,7 @@ convertParamSetToIrace = function(par.set, as.chars = FALSE) {
         stopf("Unknown parameter type: %s", p$type)
       }
       if (!is.null(p$requires)) {
-        line = paste(line, collapse(capture.output(p$requires), sep=""), sep = " | ")
+        line = paste(line, collapse(deparse(p$requires, width.cutoff = 500L), sep=""), sep = " | ")
       }
       lines[count] = line
       count = count + 1L

--- a/tests/testthat/test_convertParamSetToIrace.R
+++ b/tests/testthat/test_convertParamSetToIrace.R
@@ -34,7 +34,7 @@ test_that("convertParamSetToIrace", {
     makeDiscreteParam("x1", values = c("a", "b")),
     makeLogicalParam("x2", requires = quote(x1 == "a")),
     makeLogicalParam("x3", requires =
-      quote(x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE"))
+      quote(x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE" && x1 == "a" && x2 == "FALSE"))
   )
   ips = convertParamSetToIrace(ps)
   expect_false(identical(ips$constraints$x2, expression(TRUE)))


### PR DESCRIPTION
ironically deparse also creates line-breaks after at least 500 characters