### PR TITLE
introduce special.vals for make*Param

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 ParamHelpers_1.9:
 - Many parameters can now be expressions which can be evaluated later while
   providing a lookup dictionary.
+- make*Param now accepts special.vals which are always feasibile
 
 ParamHelpers_1.8:
 - removed soobench from SUGGESTS and removed function extractParamSetFromSooFunction

--- a/R/aParam.R
+++ b/R/aParam.R
@@ -64,6 +64,9 @@
 #'   procedures that would try to consider all available parameters.
 #'   Default is \code{TRUE} (except for \code{untyped}, \code{function}, \code{character} and
 #'   \code{characterVector}) which means it is tunable.
+#' @param special.vals [\code{list()}]\cr
+#'   A list of special values the parameter can except which are outside of the defined range.
+#'   Default is an empty list.
 #' @return [\code{\link{Param}}].
 #' @name Param
 #' @rdname Param

--- a/R/aParam.R
+++ b/R/aParam.R
@@ -75,7 +75,7 @@
 NULL
 
 makeParam = function(id, type, len, lower, upper, values, cnames, allow.inf = FALSE, default,
-  trafo = NULL, requires = NULL, tunable = TRUE) {
+  trafo = NULL, requires = NULL, tunable = TRUE, special.vals = list()) {
   assertString(id)
   #We cannot check default} for NULL or NA as this could be the default value!
   if (missing(default)) {
@@ -93,6 +93,7 @@ makeParam = function(id, type, len, lower, upper, values, cnames, allow.inf = FA
     requires = convertExpressionToCall(requires)
     assertClass(requires, "call")
   }
+  assertList(special.vals)
   p = makeS3Obj("Param",
     id = id,
     type = type,
@@ -106,7 +107,8 @@ makeParam = function(id, type, len, lower, upper, values, cnames, allow.inf = FA
     default = default,
     trafo = trafo,
     requires = requires,
-    tunable = tunable
+    tunable = tunable,
+    special.vals = special.vals
   )
   if (has.default && !isFeasible(p, default))
     stop(p$id, " : 'default' must be a feasible parameter setting.")

--- a/R/isFeasible.R
+++ b/R/isFeasible.R
@@ -109,6 +109,8 @@ isFeasible.ParamSet = function(par, x, use.defaults = FALSE, filter = FALSE) {
 
 # are the contraints ok for value of a param (not considering requires)
 constraintsOkParam = function(par, x) {
+  if (specialValsOk(par, x))
+    return(TRUE)
   type = par$type
   # this should work in any! case.
   if (type == "untyped")
@@ -145,6 +147,8 @@ constraintsOkParam = function(par, x) {
 }
 
 constraintsOkLearnerParam = function(par, x) {
+  if (specialValsOk(par, x))
+    return(TRUE)
   inValues = function(v) any(vlapply(par$values, function(w) isTRUE(all.equal(w, v))))
   type = par$type
   # extra case for unkown dim in vector
@@ -167,4 +171,8 @@ requiresOk = function(par, x) {
   } else {
     isTRUE(eval(par$requires, envir = x))
   }
+}
+
+specialValsOk = function(par, x) {
+  any(vlapply(par$special.vals, function(special.val) isTRUE(all.equal(x, special.val))))
 }

--- a/R/isFeasible.R
+++ b/R/isFeasible.R
@@ -173,6 +173,7 @@ requiresOk = function(par, x) {
   }
 }
 
+# check if x is one of the pre defined special.vals and return TRUE in case.
 specialValsOk = function(par, x) {
   any(vlapply(par$special.vals, function(special.val) isTRUE(all.equal(x, special.val))))
 }

--- a/R/makeLearnerParamFuns.R
+++ b/R/makeLearnerParamFuns.R
@@ -1,16 +1,16 @@
 #' @rdname LearnerParam
 #' @export
 makeNumericLearnerParam = function(id, lower = -Inf, upper = Inf, allow.inf = FALSE, default,
-  when = "train", requires = NULL, tunable = TRUE) {
+  when = "train", requires = NULL, tunable = TRUE, special.vals = list()) {
 
-  p = makeNumericParam(id, lower, upper, allow.inf = allow.inf, default = default, requires = requires, tunable = tunable)
+  p = makeNumericParam(id, lower, upper, allow.inf = allow.inf, default = default, requires = requires, tunable = tunable, special.vals = special.vals)
   learnerParamFromParam(p, when)
 }
 
 #' @rdname LearnerParam
 #' @export
 makeNumericVectorLearnerParam = function(id, len = as.integer(NA), lower = -Inf,
-  upper = Inf, allow.inf = FALSE, default, when = "train", requires = NULL, tunable = TRUE) {
+  upper = Inf, allow.inf = FALSE, default, when = "train", requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## makeNumericVectorParam is not able to use expressions in 'length', thus we
   ## do a dirty-hack, in which we define len = 1L for the construction of p and
@@ -25,10 +25,10 @@ makeNumericVectorLearnerParam = function(id, len = as.integer(NA), lower = -Inf,
 
   if (is.na(len))
     p = makeVectorParamNALength(makeNumericVectorParam, default = default,
-      id = id, lower = lower, upper = upper, allow.inf = allow.inf, requires = requires, tunable = tunable)
+      id = id, lower = lower, upper = upper, allow.inf = allow.inf, requires = requires, tunable = tunable, special.vals = special.vals)
   else
     p = makeNumericVectorParam(id, len = len, lower = lower, upper = upper, allow.inf = allow.inf, default =  default,
-      requires = requires, tunable = tunable)
+      requires = requires, tunable = tunable, special.vals = special.vals)
   p = learnerParamFromParam(p, when)
   ## re-insert the expression (if it existed in the beginning)
   if (!is.null(len.expr))
@@ -42,16 +42,16 @@ makeNumericVectorLearnerParam = function(id, len = as.integer(NA), lower = -Inf,
 #' @rdname LearnerParam
 #' @export
 makeIntegerLearnerParam = function(id, lower = -Inf, upper = Inf,
-  default, when = "train", requires = NULL, tunable = TRUE) {
+  default, when = "train", requires = NULL, tunable = TRUE, special.vals = list()) {
 
-  p = makeIntegerParam(id, lower, upper, default = default, requires = requires, tunable = tunable)
+  p = makeIntegerParam(id, lower, upper, default = default, requires = requires, tunable = tunable, special.vals = special.vals)
   learnerParamFromParam(p, when)
 }
 
 #' @rdname LearnerParam
 #' @export
 makeIntegerVectorLearnerParam = function(id, len = as.integer(NA), lower = -Inf,
-  upper = Inf, default, when = "train", requires = NULL, tunable = TRUE) {
+  upper = Inf, default, when = "train", requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## makeIntegerVectorParam is not able to use expressions in 'length', thus we
   ## do a dirty-hack, in which we define len = 1L for the construction of p and
@@ -65,10 +65,10 @@ makeIntegerVectorLearnerParam = function(id, len = as.integer(NA), lower = -Inf,
   }
   if (is.na(len))
     p = makeVectorParamNALength(makeIntegerVectorParam, default = default,
-      id = id, lower = lower, upper = upper, requires = requires, tunable = tunable)
+      id = id, lower = lower, upper = upper, requires = requires, tunable = tunable, special.vals = special.vals)
   else
     p = makeIntegerVectorParam(id, len = len, lower = lower, upper = upper, default = default,
-      requires = requires, tunable = tunable)
+      requires = requires, tunable = tunable, special.vals = special.vals)
   p = learnerParamFromParam(p, when)
   ## re-insert the expression (if it existed in the beginning)
   if (!is.null(len.expr))
@@ -81,16 +81,16 @@ makeIntegerVectorLearnerParam = function(id, len = as.integer(NA), lower = -Inf,
 #' @rdname LearnerParam
 #' @export
 makeDiscreteLearnerParam = function(id, values, default,
-  when = "train", requires = NULL, tunable = TRUE) {
+  when = "train", requires = NULL, tunable = TRUE, special.vals = list()) {
 
-  p = makeDiscreteParam(id, values, default = default, requires = requires, tunable = tunable)
+  p = makeDiscreteParam(id, values, default = default, requires = requires, tunable = tunable, special.vals = special.vals)
   learnerParamFromParam(p, when)
 }
 
 #' @rdname LearnerParam
 #' @export
 makeDiscreteVectorLearnerParam = function(id, len = as.integer(NA), values, default,
-  when = "train", requires = NULL, tunable = TRUE) {
+  when = "train", requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## makeDiscreteVectorParam is not able to use expressions in 'length', thus we
   ## do a dirty-hack, in which we define len = 1L for the construction of p and
@@ -105,10 +105,10 @@ makeDiscreteVectorLearnerParam = function(id, len = as.integer(NA), values, defa
 
   if (is.na(len))
     p = makeVectorParamNALength(makeDiscreteVectorParam, default = default,
-      id = id, values = values, requires = requires, tunable = tunable)
+      id = id, values = values, requires = requires, tunable = tunable, special.vals = special.vals)
   else
     p = makeDiscreteVectorParam(id, len = len, values = values, default = default, requires = requires,
-      tunable = tunable)
+      tunable = tunable, special.vals = special.vals)
   p = learnerParamFromParam(p, when)
   ## re-insert the expression (if it existed in the beginning)
   if (!is.null(len.expr))
@@ -120,16 +120,16 @@ makeDiscreteVectorLearnerParam = function(id, len = as.integer(NA), values, defa
 
 #' @rdname LearnerParam
 #' @export
-makeLogicalLearnerParam = function(id, default, when = "train", requires = NULL, tunable = TRUE) {
+makeLogicalLearnerParam = function(id, default, when = "train", requires = NULL, tunable = TRUE, special.vals = list()) {
 
-  p = makeLogicalParam(id, default = default, requires = requires, tunable = tunable)
+  p = makeLogicalParam(id, default = default, requires = requires, tunable = tunable, special.vals = special.vals)
   learnerParamFromParam(p, when)
 }
 
 #' @rdname LearnerParam
 #' @export
 makeLogicalVectorLearnerParam = function(id, len = as.integer(NA), default, when = "train",
-  requires = NULL, tunable = TRUE) {
+  requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## makeLogicalVectorParam is not able to use expressions in 'length', thus we
   ## do a dirty-hack, in which we define len = 1L for the construction of p and
@@ -144,9 +144,9 @@ makeLogicalVectorLearnerParam = function(id, len = as.integer(NA), default, when
 
   if (is.na(len))
     p = makeVectorParamNALength(makeLogicalVectorParam, default = default,
-      id = id, requires = requires, tunable = tunable)
+      id = id, requires = requires, tunable = tunable, special.vals = special.vals)
   else
-    p = makeLogicalVectorParam(id, len = len, default = default, requires = requires, tunable = tunable)
+    p = makeLogicalVectorParam(id, len = len, default = default, requires = requires, tunable = tunable, special.vals = special.vals)
   p = learnerParamFromParam(p, when)
   ## re-insert the expression (if it existed in the beginning)
   if (!is.null(len.expr))
@@ -158,15 +158,15 @@ makeLogicalVectorLearnerParam = function(id, len = as.integer(NA), default, when
 
 #' @rdname LearnerParam
 #' @export
-makeUntypedLearnerParam = function(id, default, when = "train", requires = NULL, tunable = TRUE) {
-  p = makeUntypedParam(id, default = default, requires = requires, tunable = tunable)
+makeUntypedLearnerParam = function(id, default, when = "train", requires = NULL, tunable = TRUE, special.vals = list()) {
+  p = makeUntypedParam(id, default = default, requires = requires, tunable = tunable, special.vals = special.vals)
   learnerParamFromParam(p, when)
 }
 
 #' @rdname LearnerParam
 #' @export
-makeFunctionLearnerParam = function(id, default, when = "train", requires = NULL) {
-  p = makeFunctionParam(id, default = default, requires = requires)
+makeFunctionLearnerParam = function(id, default, when = "train", requires = NULL, special.vals = list()) {
+  p = makeFunctionParam(id, default = default, requires = requires, special.vals = special.vals)
   learnerParamFromParam(p, when)
 }
 

--- a/R/makeParamFuns.R
+++ b/R/makeParamFuns.R
@@ -1,7 +1,7 @@
 #' @rdname Param
 #' @export
 makeNumericParam = function(id, lower = -Inf, upper = Inf, allow.inf = FALSE,
-  default, trafo = NULL, requires = NULL, tunable = TRUE) {
+  default, trafo = NULL, requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## Dirty hack! makeParam can not handle expressions, therefore we replace
   ## all expressions in lower, upper or defaults with feasible values prior
@@ -33,7 +33,7 @@ makeNumericParam = function(id, lower = -Inf, upper = Inf, allow.inf = FALSE,
   assertLogical(tunable, len = 1L)
   p = makeParam(id = id, type = "numeric", len = 1L, lower = lower,
     upper = upper, allow.inf = allow.inf, values = NULL, cnames = NULL,
-    default = default, trafo = trafo, requires = requires, tunable = tunable)
+    default = default, trafo = trafo, requires = requires, tunable = tunable, special.vals = special.vals)
 
   ## re-substitute the expression for lower, upper and/or default
   ## (if they existed in the first place)
@@ -50,7 +50,7 @@ makeNumericParam = function(id, lower = -Inf, upper = Inf, allow.inf = FALSE,
 #' @export
 makeNumericVectorParam = function(id, len, lower = -Inf, upper = Inf,
   allow.inf = FALSE, cnames = NULL, default, trafo = NULL, requires = NULL,
-  tunable = TRUE) {
+  tunable = TRUE, special.vals = list()) {
 
   ## replace all expressions in length, lower, upper or defaults with feasible
   ## values prior to generating the parameter (and afterwards re-substitute them
@@ -95,7 +95,7 @@ makeNumericVectorParam = function(id, len, lower = -Inf, upper = Inf,
   assertLogical(tunable, len = 1L)
   p = makeParam(id = id, type = "numericvector", len = len, lower = lower,
     upper = upper, allow.inf = allow.inf, values = NULL, cnames = cnames,
-    default = default, trafo = trafo, requires = requires, tunable = tunable)
+    default = default, trafo = trafo, requires = requires, tunable = tunable, special.vals = special.vals)
 
   ## re-substitute the expression for lower, upper and/or default
   if (!is.null(lower.expr))
@@ -112,7 +112,7 @@ makeNumericVectorParam = function(id, len, lower = -Inf, upper = Inf,
 #' @rdname Param
 #' @export
 makeIntegerParam = function(id, lower = -Inf, upper = Inf, default, trafo = NULL,
-  requires = NULL, tunable = TRUE) {
+  requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## replace all expressions in lower, upper or defaults with feasible values
   ## prior to generating the parameter (and afterwards re-substitute them by the
@@ -143,7 +143,7 @@ makeIntegerParam = function(id, lower = -Inf, upper = Inf, default, trafo = NULL
   assertLogical(tunable, len = 1L)
   p = makeParam(id = id, type = "integer", len = 1L, lower = lower,
     upper = upper, values = NULL, cnames = NULL, default = default,
-    trafo = trafo, requires = requires, tunable = tunable)
+    trafo = trafo, requires = requires, tunable = tunable, special.vals = special.vals)
 
   ## re-substitute the expression for lower, upper and/or default
   if (!is.null(lower.expr))
@@ -158,7 +158,7 @@ makeIntegerParam = function(id, lower = -Inf, upper = Inf, default, trafo = NULL
 #' @rdname Param
 #' @export
 makeIntegerVectorParam = function(id, len, lower = -Inf, upper = Inf, cnames = NULL,
-  default, trafo = NULL, requires = NULL, tunable = TRUE) {
+  default, trafo = NULL, requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## replace all expressions in length, lower, upper or defaults with feasible
   ## values prior to generating the parameter (and afterwards re-substitute them
@@ -204,7 +204,7 @@ makeIntegerVectorParam = function(id, len, lower = -Inf, upper = Inf, cnames = N
   assertLogical(tunable, len = 1L)
   p = makeParam(id = id, type = "integervector", len = len, lower = lower, upper = upper,
     values = NULL, cnames = cnames, default = default, trafo = trafo,
-    requires = requires, tunable = tunable)
+    requires = requires, tunable = tunable, special.vals = special.vals)
 
   ## re-substitute the expression for lower, upper and/or default
   if (!is.null(lower.expr))
@@ -220,7 +220,7 @@ makeIntegerVectorParam = function(id, len, lower = -Inf, upper = Inf, cnames = N
 
 #' @rdname Param
 #' @export
-makeLogicalParam = function(id, default, requires = NULL, tunable = TRUE) {
+makeLogicalParam = function(id, default, requires = NULL, tunable = TRUE, special.vals = list()) {
   values = list(TRUE, FALSE)
   names(values) = c("TRUE", "FALSE")
   assertLogical(tunable, len = 1L)
@@ -235,7 +235,7 @@ makeLogicalParam = function(id, default, requires = NULL, tunable = TRUE) {
 
   p = makeParam(id = id, type = "logical", len = 1L, lower = NULL,
     upper = NULL, values = values, cnames = NULL, default = default,
-    trafo = NULL, requires = requires, tunable = tunable)
+    trafo = NULL, requires = requires, tunable = tunable, special.vals = special.vals)
 
   ## re-substitute the expression for default
   if (!is.null(default.expr))
@@ -246,7 +246,7 @@ makeLogicalParam = function(id, default, requires = NULL, tunable = TRUE) {
 #' @rdname Param
 #' @export
 makeLogicalVectorParam = function(id, len, cnames = NULL, default,
-  requires = NULL, tunable = TRUE) {
+  requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## replace expressions in length by feasible value prior to
   ## param construction (and replace it afterwards)
@@ -274,7 +274,7 @@ makeLogicalVectorParam = function(id, len, cnames = NULL, default,
 
   p = makeParam(id = id, type = "logicalvector", len = len, lower = NULL,
     upper = NULL, values = values, cnames = cnames, default = default,
-    trafo = NULL, requires = requires, tunable = tunable)
+    trafo = NULL, requires = requires, tunable = tunable, special.vals = special.vals)
 
   ## re-substitute the expression for default
   if (!is.null(default.expr))
@@ -287,7 +287,7 @@ makeLogicalVectorParam = function(id, len, cnames = NULL, default,
 #' @rdname Param
 #' @export
 makeDiscreteParam = function(id, values, trafo = NULL, default,
-  requires = NULL, tunable = TRUE) {
+  requires = NULL, tunable = TRUE, special.vals = list()) {
 
   ## replace the expression in values and defaults with feasible values prior to
   ## generating the params (and re-substituting them by the original expression)
@@ -306,7 +306,7 @@ makeDiscreteParam = function(id, values, trafo = NULL, default,
   assertLogical(tunable, len = 1L)
   p = makeParam(id = id, type = "discrete", len = 1L, lower = NULL,
     upper = NULL, values = values, cnames = NULL, default = default,
-    trafo = trafo, requires = requires, tunable = tunable)
+    trafo = trafo, requires = requires, tunable = tunable, special.vals = special.vals)
 
   ## re-substitute the expression for default and values
   if (!is.null(default.expr))
@@ -319,7 +319,7 @@ makeDiscreteParam = function(id, values, trafo = NULL, default,
 #' @rdname Param
 #' @export
 makeDiscreteVectorParam = function(id, len, values, default, requires = NULL,
-  tunable = TRUE) {
+  tunable = TRUE, special.vals = list()) {
 
   ## replace the expressions in length with a feasible (1L) prior to generating
   ## the parameter (and afterwards re-substitute it by the original expression)
@@ -347,7 +347,7 @@ makeDiscreteVectorParam = function(id, len, values, default, requires = NULL,
   assertLogical(tunable, len = 1L)
   p = makeParam(id = id, type = "discretevector", len = len, lower = NULL,
     upper = NULL, values = values, cnames = NULL, default = default,
-    trafo = NULL, requires = requires, tunable = tunable)
+    trafo = NULL, requires = requires, tunable = tunable, special.vals = special.vals)
 
   ## re-substitute the expressions for default, values and length
   ## (if they existed in the first place)
@@ -362,34 +362,34 @@ makeDiscreteVectorParam = function(id, len, values, default, requires = NULL,
 
 #' @rdname Param
 #' @export
-makeFunctionParam = function(id, default = default, requires = NULL) {
+makeFunctionParam = function(id, default = default, requires = NULL, special.vals = list()) {
   makeParam(id = id, type = "function", len = 1L, lower = NULL, upper = NULL,
     values = NULL, cnames = NULL, default = default, trafo = NULL,
-    requires = requires, tunable = FALSE)
+    requires = requires, tunable = FALSE, special.vals = special.vals)
 }
 
 #FIXME: what happens if NA is later used for untyped params? because we might interpret this as
 # missing value wrt. dependent params
 #' @rdname Param
 #' @export
-makeUntypedParam = function(id, default, requires = NULL, tunable = TRUE) {
+makeUntypedParam = function(id, default, requires = NULL, tunable = TRUE, special.vals = list()) {
   makeParam(id = id, type = "untyped", len = 1L, lower = NULL, upper = NULL,
     values = NULL, cnames = NULL, default = default, trafo = NULL,
-    requires = requires, tunable = TRUE)
+    requires = requires, tunable = TRUE, special.vals = special.vals)
 }
 
 #' @rdname Param
 #' @export
-makeCharacterParam = function(id, default, requires = NULL) {
+makeCharacterParam = function(id, default, requires = NULL, special.vals = list()) {
   makeParam(id = id, type = "character", len = 1L, lower = NULL, upper = NULL,
     values = NULL, cnames = NULL, default = default, trafo = NULL,
-    requires = requires, tunable = FALSE)
+    requires = requires, tunable = FALSE, special.vals = special.vals)
 }
 
 #' @rdname Param
 #' @export
 makeCharacterVectorParam = function(id, len, cnames = NULL, default,
-  requires = NULL) {
+  requires = NULL, special.vals = list()) {
 
   ## replace the expressions in length with a feasible (1L) prior to generating
   ## the parameter (and afterwards re-substitute it by the original expression)
@@ -403,7 +403,7 @@ makeCharacterVectorParam = function(id, len, cnames = NULL, default,
 
   p = makeParam(id = id, type = "charactervector", len = len, lower = NULL,
     upper = NULL, values = NULL, cnames = cnames, default = default,
-    trafo = NULL, requires = requires, tunable = FALSE)
+    trafo = NULL, requires = requires, tunable = FALSE, special.vals = special.vals)
 
   ## re-substitute the length-expression (if it existed in the first place)
   if (!is.null(len.expr))

--- a/man/LearnerParam.Rd
+++ b/man/LearnerParam.Rd
@@ -94,6 +94,10 @@ procedures that would try to consider all available parameters.
 Default is \code{TRUE} (except for \code{untyped}, \code{function}, \code{character} and
 \code{characterVector}) which means it is tunable.}
 
+\item{special.vals}{[\code{list()}]\cr
+A list of special values the parameter can except which are outside of the defined range.
+Default is an empty list.}
+
 \item{len}{[\code{integer(1)}]\cr
 Length of vector parameter.}
 

--- a/man/LearnerParam.Rd
+++ b/man/LearnerParam.Rd
@@ -15,34 +15,40 @@
 \title{Create a description object for a parameter of a machine learning algorithm.}
 \usage{
 makeNumericLearnerParam(id, lower = -Inf, upper = Inf, allow.inf = FALSE,
-  default, when = "train", requires = NULL, tunable = TRUE)
+  default, when = "train", requires = NULL, tunable = TRUE,
+  special.vals = list())
 
 makeNumericVectorLearnerParam(id, len = as.integer(NA), lower = -Inf,
   upper = Inf, allow.inf = FALSE, default, when = "train",
-  requires = NULL, tunable = TRUE)
+  requires = NULL, tunable = TRUE, special.vals = list())
 
 makeIntegerLearnerParam(id, lower = -Inf, upper = Inf, default,
-  when = "train", requires = NULL, tunable = TRUE)
+  when = "train", requires = NULL, tunable = TRUE,
+  special.vals = list())
 
 makeIntegerVectorLearnerParam(id, len = as.integer(NA), lower = -Inf,
-  upper = Inf, default, when = "train", requires = NULL, tunable = TRUE)
+  upper = Inf, default, when = "train", requires = NULL, tunable = TRUE,
+  special.vals = list())
 
 makeDiscreteLearnerParam(id, values, default, when = "train",
-  requires = NULL, tunable = TRUE)
+  requires = NULL, tunable = TRUE, special.vals = list())
 
 makeDiscreteVectorLearnerParam(id, len = as.integer(NA), values, default,
-  when = "train", requires = NULL, tunable = TRUE)
+  when = "train", requires = NULL, tunable = TRUE,
+  special.vals = list())
 
 makeLogicalLearnerParam(id, default, when = "train", requires = NULL,
-  tunable = TRUE)
+  tunable = TRUE, special.vals = list())
 
 makeLogicalVectorLearnerParam(id, len = as.integer(NA), default,
-  when = "train", requires = NULL, tunable = TRUE)
+  when = "train", requires = NULL, tunable = TRUE,
+  special.vals = list())
 
 makeUntypedLearnerParam(id, default, when = "train", requires = NULL,
-  tunable = TRUE)
+  tunable = TRUE, special.vals = list())
 
-makeFunctionLearnerParam(id, default, when = "train", requires = NULL)
+makeFunctionLearnerParam(id, default, when = "train", requires = NULL,
+  special.vals = list())
 }
 \arguments{
 \item{id}{[\code{character(1)}]\cr

--- a/man/Param.Rd
+++ b/man/Param.Rd
@@ -100,6 +100,10 @@ procedures that would try to consider all available parameters.
 Default is \code{TRUE} (except for \code{untyped}, \code{function}, \code{character} and
 \code{characterVector}) which means it is tunable.}
 
+\item{special.vals}{[\code{list()}]\cr
+A list of special values the parameter can except which are outside of the defined range.
+Default is an empty list.}
+
 \item{len}{[\code{integer(1)}]\cr
 Length of vector parameter.}
 

--- a/man/Param.Rd
+++ b/man/Param.Rd
@@ -17,36 +17,42 @@
 \title{Create a description object for a parameter.}
 \usage{
 makeNumericParam(id, lower = -Inf, upper = Inf, allow.inf = FALSE,
-  default, trafo = NULL, requires = NULL, tunable = TRUE)
+  default, trafo = NULL, requires = NULL, tunable = TRUE,
+  special.vals = list())
 
 makeNumericVectorParam(id, len, lower = -Inf, upper = Inf,
   allow.inf = FALSE, cnames = NULL, default, trafo = NULL,
-  requires = NULL, tunable = TRUE)
+  requires = NULL, tunable = TRUE, special.vals = list())
 
 makeIntegerParam(id, lower = -Inf, upper = Inf, default, trafo = NULL,
-  requires = NULL, tunable = TRUE)
+  requires = NULL, tunable = TRUE, special.vals = list())
 
 makeIntegerVectorParam(id, len, lower = -Inf, upper = Inf, cnames = NULL,
-  default, trafo = NULL, requires = NULL, tunable = TRUE)
+  default, trafo = NULL, requires = NULL, tunable = TRUE,
+  special.vals = list())
 
-makeLogicalParam(id, default, requires = NULL, tunable = TRUE)
+makeLogicalParam(id, default, requires = NULL, tunable = TRUE,
+  special.vals = list())
 
 makeLogicalVectorParam(id, len, cnames = NULL, default, requires = NULL,
-  tunable = TRUE)
+  tunable = TRUE, special.vals = list())
 
 makeDiscreteParam(id, values, trafo = NULL, default, requires = NULL,
-  tunable = TRUE)
+  tunable = TRUE, special.vals = list())
 
 makeDiscreteVectorParam(id, len, values, default, requires = NULL,
-  tunable = TRUE)
+  tunable = TRUE, special.vals = list())
 
-makeFunctionParam(id, default = default, requires = NULL)
+makeFunctionParam(id, default = default, requires = NULL,
+  special.vals = list())
 
-makeUntypedParam(id, default, requires = NULL, tunable = TRUE)
+makeUntypedParam(id, default, requires = NULL, tunable = TRUE,
+  special.vals = list())
 
-makeCharacterParam(id, default, requires = NULL)
+makeCharacterParam(id, default, requires = NULL, special.vals = list())
 
-makeCharacterVectorParam(id, len, cnames = NULL, default, requires = NULL)
+makeCharacterVectorParam(id, len, cnames = NULL, default, requires = NULL,
+  special.vals = list())
 }
 \arguments{
 \item{id}{[\code{character(1)}]\cr

--- a/tests/testthat/test_LearnerParam.R
+++ b/tests/testthat/test_LearnerParam.R
@@ -8,11 +8,12 @@ test_that("num vec", {
   expect_equal(p$when, "train")
   expect_true(!isFeasible(p, 1))
   expect_true(isFeasible(p, c(1,1)))
-  p = makeNumericVectorLearnerParam("x", lower = 0, upper = 2)
+  p = makeNumericVectorLearnerParam("x", lower = 0, upper = 2, special.vals = list(NA_integer_))
   expect_equal(p$lower, 0)
   expect_equal(p$upper, 2)
   expect_true(isFeasible(p, 1))
   expect_true(isFeasible(p, c(1,1)))
+  expect_true(isFeasible(p, NA_integer_))
   # defaults
   p = makeNumericVectorLearnerParam(id = "x", allow.inf = TRUE, default = Inf)
   expect_error(makeNumericVectorLearnerParam(id = "x", allow.inf = FALSE, default = Inf), "feasible")

--- a/tests/testthat/test_Param.R
+++ b/tests/testthat/test_Param.R
@@ -16,11 +16,14 @@ test_that("num param", {
   expect_true(!isFeasible(p, NA))
   expect_true(!isFeasible(p, "bam"))
 
-  p = makeNumericParam(id = "x", lower = 0, upper = Inf)
+  p = makeNumericParam(id = "x", lower = 0, upper = Inf, special.vals = list(NA_real_, function(x) x + 1, matrix()))
   expect_true(isFeasible(p, 2))
   expect_true(!isFeasible(p, -2))
   expect_true(!isFeasible(p, -Inf))
   expect_true(!isFeasible(p, NULL))
+  expect_true(isFeasible(p, NA_real_))
+  expect_true(isFeasible(p, function(x) x + 1))
+  expect_true(isFeasible(p, matrix()))
 
   expect_equal(p$values, NULL)
 
@@ -57,11 +60,12 @@ test_that("num vec param", {
   expect_true(!isFeasible(p, NA))
   expect_true(!isFeasible(p, "bam"))
 
-  p = makeNumericVectorParam(id = "x", lower = 0, upper = Inf, len = 3)
+  p = makeNumericVectorParam(id = "x", lower = 0, upper = Inf, len = 3, special.vals = list(-Inf))
   expect_true(isFeasible(p, c(2,1,1)))
   expect_true(!isFeasible(p, c(-2,1,0)))
   expect_true(!isFeasible(p, c(-Inf, 1)))
   expect_true(!isFeasible(p, NULL))
+  expect_true(isFeasible(p, -Inf))
 
   ## Error conditions:
   expect_error(makeNumericVectorParam(id = "x", lower = "bam", upper = 1))


### PR DESCRIPTION
Now it is possible to allow for special values outside of constraint area to be feasible.

```r
p = makeNumericParam(id = "x", lower = 0, upper = Inf, special.vals = list(-Inf))
isFeasible(p, -Inf)
# TRUE
```