### PR TITLE
Fix getDefaults for VectorLearnerParams without defined length

### DIFF
--- a/R/getDefaults.R
+++ b/R/getDefaults.R
@@ -31,7 +31,7 @@ getDefaults = function(par.set, include.null = FALSE, dict = NULL) {
       def = defs[[id]]
       if (is.expression(def))
         def = eval(def, envir = dict)
-      if ((length(def) == 1L) && par.set$pars[[id]]$len > 1L)
+      if ((length(def) == 1L) && !is.na(par.set$pars[[id]]$len) && par.set$pars[[id]]$len > 1L)
         def = rep(def, par.set$pars[[id]]$len)
       return(def)
     }), ids)

--- a/tests/testthat/test_getDefaults.R
+++ b/tests/testthat/test_getDefaults.R
@@ -38,11 +38,12 @@ test_that("getDefaults for LearnerParams", {
     makeDiscreteLearnerParam(id = "a", default = "a1", values = c("a1", "a2")),
     makeNumericLearnerParam(id = "b",  default = 1, lower = 0, requires = quote(a=="a1")),
     makeNumericVectorLearnerParam("c", len = NA_integer_, lower = 0),
-    makeLogicalVectorLearnerParam(id = "d", default = c(TRUE), tunable = TRUE)
+    makeLogicalVectorLearnerParam(id = "d", default = c(TRUE), tunable = TRUE),
+    makeIntegerVectorLearnerParam(id = "e", default = 1:3)
   )
   expect_equal(
     getDefaults(par.set, include.null = TRUE),
-    list(a = "a1", b = 1, c = NULL, d = TRUE)
+    list(a = "a1", b = 1, c = NULL, d = TRUE, e = 1:3)
   )
 })
 

--- a/tests/testthat/test_getDefaults.R
+++ b/tests/testthat/test_getDefaults.R
@@ -33,3 +33,16 @@ test_that("getDefaults", {
   )
 })
 
+test_that("getDefaults for LearnerParams", {
+  par.set = makeParamSet(
+    makeDiscreteLearnerParam(id = "a", default = "a1", values = c("a1", "a2")),
+    makeNumericLearnerParam(id = "b",  default = 1, lower = 0, requires = quote(a=="a1")),
+    makeNumericVectorLearnerParam("c", len = NA_integer_, lower = 0),
+    makeLogicalVectorLearnerParam(id = "d", default = c(TRUE), tunable = TRUE)
+  )
+  expect_equal(
+    getDefaults(par.set, include.null = TRUE),
+    list(a = "a1", b = 1, c = NULL, d = TRUE)
+  )
+})
+


### PR DESCRIPTION
It is possible to generate VectorParams without a defined length. This was not handled correctly by getDefaults but it is now and also tested.