### PR TITLE
fix: updateParVals also respects defaults to not drop old.par.vals

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,5 @@ man-roxygen
 README.md
 ^.editorconfig$
 ^appveyor\.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/tests/testthat/test_updateParVals.R
+++ b/tests/testthat/test_updateParVals.R
@@ -2,15 +2,17 @@ context("updateParVals")
 
 test_that("updateParVals works", {
   #simple dependency
-  pa = list(a = 1, b = 2, d = 4)
+  pa = list(a = 1, b = 2, d = 4, e = 5)
   pb = list(a = 0, c = 3)
   ps = makeParamSet(
     makeIntegerParam("a"),
     makeIntegerParam("b", requires = quote(a == 1)),
     makeIntegerParam("c"),
-    makeIntegerParam("d"))
+    makeIntegerParam("d"),
+    makeIntegerParam("e", requires = quote(f == TRUE)),
+    makeLogicalParam("f", default = TRUE))
   pc = updateParVals(ps, pa, pb)
-  expect_equal(pc, list(a = 0, c = 3, d = 4))
+  expect_equal(pc, list(a = 0, c = 3, d = 4, e = 5))
   expect_warning(updateParVals(ps, pa, pb, warn = TRUE), "ParamSetting b=2")
 
   #sanity
@@ -21,10 +23,11 @@ test_that("updateParVals works", {
   pa = list(a = 1, b = 2, c = 0.5, d = 4)
   pb = list(a = -3)
   ps = makeParamSet(
-    makeIntegerParam("a"),
+    makeIntegerParam("a", requires = quote(e == TRUE)),
     makeIntegerParam("b", requires = quote(a == 1)),
     makeNumericParam("c"),
-    makeIntegerParam("d", requires = quote(b == 2)))
+    makeIntegerParam("d", requires = quote(b == 2)),
+    makeLogicalParam("e", default = TRUE))
   pc = updateParVals(ps, pa, pb)
   expect_equal(pc, list(a = -3, c = 0.5))
 })


### PR DESCRIPTION
`updateParVals` ignored the defaults of the param set and dropped old params.

```r
pa = list(a = 1)
pb = list()
ps = makeParamSet(
  makeIntegerParam("a", requires = quote(b == 1)),
  makeIntegerParam("b", default = 1))
updateParVals(ps, pa, pb)
# old behaviour: list()
# new behaviour: $a [1] 1