### PR TITLE
Allow to insert expressions in paramValueToString

### DIFF
--- a/R/paramValueToString.R
+++ b/R/paramValueToString.R
@@ -53,10 +53,13 @@ paramValueToString.Param = function(par, x, show.missing.values = FALSE, num.for
     else
       return("")
   }
+    
 
   # FIXME: switch
   type = par$type
-  if (type == "numeric")
+  if (is.expression(x))
+    as.character(x)
+  else if (type == "numeric")
     sprintf(num.format, x)
   else if (type == "numericvector")
     paste(sprintf(num.format, x), collapse=",")

--- a/R/paramValueToString.R
+++ b/R/paramValueToString.R
@@ -53,7 +53,6 @@ paramValueToString.Param = function(par, x, show.missing.values = FALSE, num.for
     else
       return("")
   }
-    
 
   # FIXME: switch
   type = par$type

--- a/tests/testthat/test_paramValueToString.R
+++ b/tests/testthat/test_paramValueToString.R
@@ -23,6 +23,7 @@ test_that("paramValueToString ", {
   expect_equal(paramValueToString(ps, list(u = 1, v = 1:2, w = list(), x = FALSE,
     y = c(TRUE, FALSE), z = list(1, list()), s = "PH")),
     "u=1; v=1,2; w=b; x=FALSE; y=TRUE,FALSE; z=a,b; s=PH")
+  paramValueToString(u, expression(ceiling(n / 3)))
 })
 
 test_that("requires works", {

--- a/tests/testthat/test_paramValueToString.R
+++ b/tests/testthat/test_paramValueToString.R
@@ -23,7 +23,8 @@ test_that("paramValueToString ", {
   expect_equal(paramValueToString(ps, list(u = 1, v = 1:2, w = list(), x = FALSE,
     y = c(TRUE, FALSE), z = list(1, list()), s = "PH")),
     "u=1; v=1,2; w=b; x=FALSE; y=TRUE,FALSE; z=a,b; s=PH")
-  paramValueToString(u, expression(ceiling(n / 3)))
+  expect_equal(paramValueToString(u, expression(ceiling(n / 3))),
+    "ceiling(n/3)")
 })
 
 test_that("requires works", {


### PR DESCRIPTION
Apparently, we were only (accidently) able to print expressions for certain types of parameters. But for numeric parameters we got an error, because we tried to convert an expression into a numeric.
With this PR, we catch expressions and print them right away (before checking any parameter types)..