### PR TITLE
hasFiniteBoxConstraints works for a single Param with expressions

### DIFF
--- a/R/hasFiniteBoxConstraints.R
+++ b/R/hasFiniteBoxConstraints.R
@@ -10,7 +10,7 @@ hasFiniteBoxConstraints = function(par, dict = NULL) {
 
 #' @export
 hasFiniteBoxConstraints.Param = function(par, dict = NULL) {
-  bounds = c(par$lower, par$upper)
+  bounds = c(getUpper(par, dict = dict), getUpper(par, dict = dict))
   if (length(bounds) == 0)
     return(TRUE)
   return(all(is.finite(bounds)))

--- a/R/hasFiniteBoxConstraints.R
+++ b/R/hasFiniteBoxConstraints.R
@@ -10,7 +10,7 @@ hasFiniteBoxConstraints = function(par, dict = NULL) {
 
 #' @export
 hasFiniteBoxConstraints.Param = function(par, dict = NULL) {
-  bounds = c(getUpper(par, dict = dict), getUpper(par, dict = dict))
+  bounds = c(getLower(par, dict = dict), getUpper(par, dict = dict))
   if (length(bounds) == 0)
     return(TRUE)
   return(all(is.finite(bounds)))

--- a/tests/testthat/test_hasFiniteBoxConstraints.R
+++ b/tests/testthat/test_hasFiniteBoxConstraints.R
@@ -10,6 +10,10 @@ test_that("hasFiniteBoxConstraints", {
   par = makeNumericParam("x", lower = -10, upper = 10)
   expect_true(hasFiniteBoxConstraints(par))
 
+  par = makeNumericParam("x", lower = 0, upper = expression(n))
+  expect_true(hasFiniteBoxConstraints(par, dict = list(n = 10)))
+  expect_false(hasFiniteBoxConstraints(par, dict = list(n = Inf)))
+
   par.set = makeParamSet(
     makeNumericParam("numeric1", lower = -100, upper = 100),
     makeIntegerParam("integer1", lower = 0L, upper = 15L)


### PR DESCRIPTION
We might also want to adapt this for a single Parameter.

Maybe not so necessary?
Speed issue?