### PR TITLE
Fix eafplot bug + exporting

### DIFF
--- a/R/OptPath_plotEAF.R
+++ b/R/OptPath_plotEAF.R
@@ -79,14 +79,14 @@ plotEAF = function(opt.paths, xlim = NULL, ylim = NULL, ...) {
     col = c("darkgrey", "darkgrey", "darkgrey", "black", "black", "black"),
     lty =  c("solid", "dashed", "dotdash", "solid", "dashed", "dotdash")
   )
-  args = list(...)
-  args = insert(defaults, args)
-  args$x = f
+  dots = list(...)
+  dots = insert(defaults, dots)
+  args = list(f)
   args$data = data
   args$groups = quote(.algo)
   args$maximise = !minimize
   args$xlim = xlim
   args$ylim = ylim
-  do.call(eaf::eafplot, args)
+  do.call(eaf::eafplot, c(args, dots))
   return(data)
 }

--- a/R/OptPath_plotEAF.R
+++ b/R/OptPath_plotEAF.R
@@ -79,14 +79,13 @@ plotEAF = function(opt.paths, xlim = NULL, ylim = NULL, ...) {
     col = c("darkgrey", "darkgrey", "darkgrey", "black", "black", "black"),
     lty =  c("solid", "dashed", "dotdash", "solid", "dashed", "dotdash")
   )
-  dots = list(...)
-  dots = insert(defaults, dots)
-  args = list(f)
+  args = list(...)
+  args = insert(defaults, args)
   args$data = data
   args$groups = quote(.algo)
   args$maximise = !minimize
   args$xlim = xlim
   args$ylim = ylim
-  do.call(eaf::eafplot, c(args, dots))
+  do.call(eaf::eafplot, c(list(f), args)) # due to not so good programming in eafplot the first argument can not be named if it's a formula
   return(data)
 }

--- a/man/LearnerParam.Rd
+++ b/man/LearnerParam.Rd
@@ -85,8 +85,6 @@ this parameter only makes sense if its requirements are satisfied (dependent par
 Can be an object created either with \code{expression} or \code{quote},
 the former type is auto-converted into the later.
 Only really useful if the parameter is included in a \code{\link{ParamSet}}.
-Note that if your dependent parameter is a logical Boolean you need to verbosely write
-\code{requires = quote(a == TRUE)} and not \code{requires = quote(a)}.
 Default is \code{NULL} which means no requirements.}
 
 \item{tunable}{[\code{logical(1)}]\cr

--- a/man/Param.Rd
+++ b/man/Param.Rd
@@ -91,8 +91,6 @@ this parameter only makes sense if its requirements are satisfied (dependent par
 Can be an object created either with \code{expression} or \code{quote},
 the former type is auto-converted into the later.
 Only really useful if the parameter is included in a \code{\link{ParamSet}}.
-Note that if your dependent parameter is a logical Boolean you need to verbosely write
-\code{requires = quote(a == TRUE)} and not \code{requires = quote(a)}.
 Default is \code{NULL} which means no requirements.}
 
 \item{tunable}{[\code{logical(1)}]\cr

--- a/tests/testthat/test_LearnerParam.R
+++ b/tests/testthat/test_LearnerParam.R
@@ -81,8 +81,8 @@ test_that("untyped", {
 })
 
 
-if (interactive()) {
 test_that("s3 objs works for values", {
+  skip_if_not_installed("mboost")
   library(mboost)
   vals = list(a = AdaExp(), b = Binomial())
   p = makeDiscreteLearnerParam("x", values = vals)
@@ -90,7 +90,6 @@ test_that("s3 objs works for values", {
   p = makeDiscreteLearnerParam("x", values = vals, default = AdaExp())
   capture.output(print(p))
 })
-}
 
 test_that("unknown length works", {
   p = makeNumericVectorLearnerParam("x", len = NA, lower = 1)

--- a/tests/testthat/test_LearnerParam.R
+++ b/tests/testthat/test_LearnerParam.R
@@ -81,14 +81,16 @@ test_that("untyped", {
 })
 
 
-test_that("s3 objs works for values", {
-  skip_if_not_installed("mboost")
-  library(mboost)
-  vals = list(a = AdaExp(), b = Binomial())
+test_that("s4 objs works for values", {
+  setClass("Dummy", representation(name = "character", id = "numeric"))
+  obj.a = new("Dummy", name = "foo", id = 1)
+  obj.b = new("Dummy", name = "bar", id = 2)
+  vals = list(a = obj.a, b = obj.b)
   p = makeDiscreteLearnerParam("x", values = vals)
-  expect_true(isFeasible(p, AdaExp()))
-  p = makeDiscreteLearnerParam("x", values = vals, default = AdaExp())
-  capture.output(print(p))
+  expect_true(isFeasible(p, new("Dummy", name = "foo", id = 1)))
+  expect_false(isFeasible(p, new("Dummy", name = "foo", id = 2)))
+  p = makeDiscreteLearnerParam("x", values = vals, default = new("Dummy", name = "foo", id = 1))
+  expect_output(print(p), "a,b")
 })
 
 test_that("unknown length works", {

--- a/tests/testthat/test_generateDesign.R
+++ b/tests/testthat/test_generateDesign.R
@@ -208,7 +208,8 @@ test_that("list of further arguments passed to lhs function produces no error", 
     makeDiscreteParam("x", values = c("a", "b", "c")),
     makeNumericParam("realA", lower = 0, upper = 100)
   )
-  generateDesign(10L, ps, fun.args = list(preserveDraw = TRUE))
+  des = generateDesign(10L, ps, fun.args = list(preserveDraw = TRUE))
+  expect_data_frame(des)
 })
 
 test_that("removing duplicates", {


### PR DESCRIPTION
I changed `"s3 objs works for values"` to `s4` because mboost created s4 objects. We already have tests for s3 indirectly. 
Also I changed the values to dummy s4 objects to avoid having to write `mboost` to the suggests.