### PR TITLE
add 'distinct' argument to VectorParams

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,5 @@ Suggests:
 LazyData: yes
 ByteCompile: yes
 Version: 1.11
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
+Encoding: UTF-8

--- a/R/aParam.R
+++ b/R/aParam.R
@@ -24,6 +24,7 @@
 #'   \item{default [any concrete value | \code{expression}]}{See argument of same name.}
 #'   \item{has.default [\code{logical(1)}]}{Extra flag to really be able to check whether the user passed a default, to avoid troubles with \code{NULL} and \code{NA}.}
 #'   \item{tunable [\code{logical(1)}]}{See argument of same name.}
+#'   \item{distinct [\code{logical(1)}]}{See argument of same name.}
 #'   \item{special.vals [\code{list}]}{See argument of same name.}
 #' }
 #'
@@ -75,6 +76,9 @@
 #'   Defining a parameter to be not-tunable allows to mark arguments like, e.g., \dQuote{verbose} or other purely technical stuff.
 #'   Note that this flag is most likely not respected by optimizing procedures unless stated otherwise.
 #'   Default is \code{TRUE} (except for \code{untyped}, \code{function}, \code{character} and \code{characterVector}) which means it is tunable.
+#' @param distinct [\code{logical(1)}]\cr
+#'   Whether sampling with or without replacement should be done for vector params.
+#'   Default is to sample with replacment (\code{distinct = FALSE}).
 #' @param special.vals [\code{list()}]\cr
 #'   A list of special values the parameter can except which are outside of the defined range.
 #'   Default is an empty list.

--- a/R/aParam.R
+++ b/R/aParam.R
@@ -89,7 +89,7 @@
 NULL
 
 makeParam = function(id, type, learner.param, len = 1L, lower = NULL, upper = NULL, values = NULL, cnames = NULL, allow.inf = FALSE, default,
-  trafo = NULL, requires = NULL, tunable = TRUE, special.vals = list(), when) {
+  trafo = NULL, requires = NULL, distinct = FALSE, tunable = TRUE, special.vals = list(), when) {
   assertString(id)
   assert(
     checkCount(len, na.ok = learner.param),
@@ -160,6 +160,7 @@ makeParam = function(id, type, learner.param, len = 1L, lower = NULL, upper = NU
     default = default,
     trafo = trafo,
     requires = requires,
+    distinct = distinct,
     tunable = tunable,
     special.vals = special.vals
   )

--- a/R/makeParamFuns.R
+++ b/R/makeParamFuns.R
@@ -50,11 +50,11 @@ makeLogicalParam = function(id, default, requires = NULL, tunable = TRUE, specia
 #' @rdname Param
 #' @export
 makeLogicalVectorParam = function(id, len, cnames = NULL, default,
-  requires = NULL, tunable = TRUE, special.vals = list()) {
+  requires = NULL, tunable = TRUE, trafo = NULL, special.vals = list()) {
   values = list("TRUE" = TRUE, "FALSE" = FALSE)
   makeParam(id = id, type = "logicalvector", learner.param = FALSE, len = len,
     values = values, cnames = cnames, default = default,
-    trafo = NULL, requires = requires, tunable = tunable, special.vals = special.vals)
+    trafo = trafo, requires = requires, tunable = tunable, special.vals = special.vals)
 }
 
 #' @rdname Param

--- a/R/makeParamFuns.R
+++ b/R/makeParamFuns.R
@@ -11,11 +11,12 @@ makeNumericParam = function(id, lower = -Inf, upper = Inf, allow.inf = FALSE,
 #' @rdname Param
 #' @export
 makeNumericVectorParam = function(id, len, lower = -Inf, upper = Inf, cnames = NULL,
-  allow.inf = FALSE, default, trafo = NULL, requires = NULL,
+  allow.inf = FALSE, default, trafo = NULL, requires = NULL, distinct = FALSE,
   tunable = TRUE, special.vals = list()) {
   makeParam(id = id, type = "numericvector", learner.param = FALSE, len = len, lower = lower,
     upper = upper, cnames = cnames, allow.inf = allow.inf,
-    default = default, trafo = trafo, requires = requires, tunable = tunable, special.vals = special.vals)
+    default = default, trafo = trafo, requires = requires, tunable = tunable,
+    distinct = distinct, special.vals = special.vals)
 }
 
 #' @rdname Param
@@ -30,10 +31,11 @@ makeIntegerParam = function(id, lower = -Inf, upper = Inf, default, trafo = NULL
 #' @rdname Param
 #' @export
 makeIntegerVectorParam = function(id, len, lower = -Inf, upper = Inf, cnames = NULL,
-  default, trafo = NULL, requires = NULL, tunable = TRUE, special.vals = list()) {
+  default, trafo = NULL, requires = NULL, tunable = TRUE,
+  distinct = FALSE, special.vals = list()) {
   makeParam(id = id, type = "integervector", learner.param = FALSE, len = len, lower = lower, upper = upper,
     cnames = cnames, default = default, trafo = trafo,
-    requires = requires, tunable = tunable, special.vals = special.vals)
+    requires = requires, tunable = tunable, distinct = distinct, special.vals = special.vals)
 }
 
 #' @rdname Param
@@ -70,8 +72,9 @@ makeDiscreteVectorParam = function(id, len, values, default, requires = NULL,
   tunable = TRUE, distinct = FALSE, special.vals = list()) {
 
   makeParam(id = id, type = "discretevector", learner.param = FALSE, len = len,
-    values = values, default = default, distinct = distinct,
-    trafo = NULL, requires = requires, tunable = tunable, special.vals = special.vals)
+    values = values, default = default,
+    trafo = NULL, requires = requires, tunable = tunable,
+    distinct = distinct, special.vals = special.vals)
 }
 
 #' @rdname Param
@@ -103,10 +106,11 @@ makeCharacterParam = function(id, default, requires = NULL, special.vals = list(
 #' @rdname Param
 #' @export
 makeCharacterVectorParam = function(id, len, cnames = NULL, default,
-  requires = NULL, special.vals = list()) {
+  requires = NULL, distinct = FALSE, special.vals = list()) {
 
   makeParam(id = id, type = "charactervector", learner.param = FALSE, len = len,
     cnames = cnames, default = default,
-    trafo = NULL, requires = requires, tunable = FALSE, special.vals = special.vals)
+    trafo = NULL, requires = requires, tunable = FALSE,
+    distinct = distinct, special.vals = special.vals)
 }
 

--- a/R/makeParamFuns.R
+++ b/R/makeParamFuns.R
@@ -67,10 +67,10 @@ makeDiscreteParam = function(id, values, trafo = NULL, default,
 #' @rdname Param
 #' @export
 makeDiscreteVectorParam = function(id, len, values, default, requires = NULL,
-  tunable = TRUE, special.vals = list()) {
+  tunable = TRUE, distinct = FALSE, special.vals = list()) {
 
   makeParam(id = id, type = "discretevector", learner.param = FALSE, len = len,
-    values = values, default = default,
+    values = values, default = default, distinct = distinct,
     trafo = NULL, requires = requires, tunable = tunable, special.vals = special.vals)
 }
 

--- a/R/sample.R
+++ b/R/sample.R
@@ -51,7 +51,11 @@ sampleValue.Param = function(par, discrete.names = FALSE, trafo = FALSE) {
   } else if (isLogicalTypeString(type)) {
     x = sample(c(TRUE, FALSE), par$len, replace = TRUE)
   } else if (isDiscreteTypeString(type, FALSE)) {
-    x = sample(names(par$values), par$len, replace = TRUE)
+    if (isTRUE(par$distinct)) {
+      x = sample(names(par$values), par$len, replace = FALSE)
+    } else {
+      x = sample(names(par$values), par$len, replace = TRUE)
+    }
     if (!discrete.names) {
       x = if (type  == "discretevector")
         par$values[x]

--- a/man/LearnerParam.Rd
+++ b/man/LearnerParam.Rd
@@ -14,9 +14,9 @@
 \alias{makeFunctionLearnerParam}
 \title{Create a description object for a parameter of a machine learning algorithm.}
 \usage{
-makeNumericLearnerParam(id, lower = -Inf, upper = Inf, allow.inf = FALSE,
-  default, when = "train", requires = NULL, tunable = TRUE,
-  special.vals = list())
+makeNumericLearnerParam(id, lower = -Inf, upper = Inf,
+  allow.inf = FALSE, default, when = "train", requires = NULL,
+  tunable = TRUE, special.vals = list())
 
 makeNumericVectorLearnerParam(id, len = as.integer(NA), lower = -Inf,
   upper = Inf, allow.inf = FALSE, default, when = "train",
@@ -27,8 +27,8 @@ makeIntegerLearnerParam(id, lower = -Inf, upper = Inf, default,
   special.vals = list())
 
 makeIntegerVectorLearnerParam(id, len = as.integer(NA), lower = -Inf,
-  upper = Inf, default, when = "train", requires = NULL, tunable = TRUE,
-  special.vals = list())
+  upper = Inf, default, when = "train", requires = NULL,
+  tunable = TRUE, special.vals = list())
 
 makeDiscreteLearnerParam(id, values, default, when = "train",
   requires = NULL, tunable = TRUE, special.vals = list())
@@ -89,11 +89,9 @@ Default is \code{NULL} which means no requirements.}
 
 \item{tunable}{[\code{logical(1)}]\cr
 Is this parameter tunable?
-Defining a parameter to be not-tunable allows to mark arguments like, e.g., \dQuote{verbose} or
-other purely technical stuff, and allows them to be excluded from later automatic optimization
-procedures that would try to consider all available parameters.
-Default is \code{TRUE} (except for \code{untyped}, \code{function}, \code{character} and
-\code{characterVector}) which means it is tunable.}
+Defining a parameter to be not-tunable allows to mark arguments like, e.g., \dQuote{verbose} or other purely technical stuff.
+Note that this flag is most likely not respected by optimizing procedures unless stated otherwise.
+Default is \code{TRUE} (except for \code{untyped}, \code{function}, \code{character} and \code{characterVector}) which means it is tunable.}
 
 \item{special.vals}{[\code{list()}]\cr
 A list of special values the parameter can except which are outside of the defined range.

--- a/man/OptPath.Rd
+++ b/man/OptPath.Rd
@@ -87,3 +87,4 @@ Other optpath: \code{\link{addOptPathEl}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/Param.Rd
+++ b/man/Param.Rd
@@ -20,28 +20,30 @@ makeNumericParam(id, lower = -Inf, upper = Inf, allow.inf = FALSE,
   default, trafo = NULL, requires = NULL, tunable = TRUE,
   special.vals = list())
 
-makeNumericVectorParam(id, len, lower = -Inf, upper = Inf, cnames = NULL,
-  allow.inf = FALSE, default, trafo = NULL, requires = NULL,
-  tunable = TRUE, special.vals = list())
-
-makeIntegerParam(id, lower = -Inf, upper = Inf, default, trafo = NULL,
-  requires = NULL, tunable = TRUE, special.vals = list())
-
-makeIntegerVectorParam(id, len, lower = -Inf, upper = Inf, cnames = NULL,
-  default, trafo = NULL, requires = NULL, tunable = TRUE,
+makeNumericVectorParam(id, len, lower = -Inf, upper = Inf,
+  cnames = NULL, allow.inf = FALSE, default, trafo = NULL,
+  requires = NULL, distinct = FALSE, tunable = TRUE,
   special.vals = list())
+
+makeIntegerParam(id, lower = -Inf, upper = Inf, default,
+  trafo = NULL, requires = NULL, tunable = TRUE,
+  special.vals = list())
+
+makeIntegerVectorParam(id, len, lower = -Inf, upper = Inf,
+  cnames = NULL, default, trafo = NULL, requires = NULL,
+  tunable = TRUE, distinct = FALSE, special.vals = list())
 
 makeLogicalParam(id, default, requires = NULL, tunable = TRUE,
   special.vals = list())
 
-makeLogicalVectorParam(id, len, cnames = NULL, default, requires = NULL,
-  tunable = TRUE, special.vals = list())
+makeLogicalVectorParam(id, len, cnames = NULL, default,
+  requires = NULL, tunable = TRUE, special.vals = list())
 
 makeDiscreteParam(id, values, trafo = NULL, default, requires = NULL,
   tunable = TRUE, special.vals = list())
 
 makeDiscreteVectorParam(id, len, values, default, requires = NULL,
-  tunable = TRUE, special.vals = list())
+  tunable = TRUE, distinct = FALSE, special.vals = list())
 
 makeFunctionParam(id, default = default, requires = NULL,
   special.vals = list())
@@ -51,8 +53,8 @@ makeUntypedParam(id, default, requires = NULL, tunable = TRUE,
 
 makeCharacterParam(id, default, requires = NULL, special.vals = list())
 
-makeCharacterVectorParam(id, len, cnames = NULL, default, requires = NULL,
-  special.vals = list())
+makeCharacterVectorParam(id, len, cnames = NULL, default,
+  requires = NULL, distinct = FALSE, special.vals = list())
 }
 \arguments{
 \item{id}{[\code{character(1)}]\cr
@@ -95,11 +97,9 @@ Default is \code{NULL} which means no requirements.}
 
 \item{tunable}{[\code{logical(1)}]\cr
 Is this parameter tunable?
-Defining a parameter to be not-tunable allows to mark arguments like, e.g., \dQuote{verbose} or
-other purely technical stuff, and allows them to be excluded from later automatic optimization
-procedures that would try to consider all available parameters.
-Default is \code{TRUE} (except for \code{untyped}, \code{function}, \code{character} and
-\code{characterVector}) which means it is tunable.}
+Defining a parameter to be not-tunable allows to mark arguments like, e.g., \dQuote{verbose} or other purely technical stuff.
+Note that this flag is most likely not respected by optimizing procedures unless stated otherwise.
+Default is \code{TRUE} (except for \code{untyped}, \code{function}, \code{character} and \code{characterVector}) which means it is tunable.}
 
 \item{special.vals}{[\code{list()}]\cr
 A list of special values the parameter can except which are outside of the defined range.
@@ -112,6 +112,10 @@ Length of vector parameter.}
 Component names for vector params (except discrete).
 Every function in this package that creates vector values for such a param, will name
 that vector with \code{cnames}.}
+
+\item{distinct}{[\code{logical(1)}]\cr
+Whether sampling with or without replacement should be done for vector params.
+Default is to sample with replacment (\code{distinct = FALSE}).}
 
 \item{values}{[\code{vector} | \code{list} | \code{expression}]\cr
 Possible discrete values. Instead of using a vector of atomic values,
@@ -147,6 +151,7 @@ The S3 class is a list which stores these elements:
   \item{default [any concrete value | \code{expression}]}{See argument of same name.}
   \item{has.default [\code{logical(1)}]}{Extra flag to really be able to check whether the user passed a default, to avoid troubles with \code{NULL} and \code{NA}.}
   \item{tunable [\code{logical(1)}]}{See argument of same name.}
+  \item{distinct [\code{logical(1)}]}{See argument of same name.}
   \item{special.vals [\code{list}]}{See argument of same name.}
 }
 }

--- a/man/addOptPathEl.Rd
+++ b/man/addOptPathEl.Rd
@@ -85,3 +85,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/as.data.frame.OptPathDF.Rd
+++ b/man/as.data.frame.OptPathDF.Rd
@@ -4,9 +4,9 @@
 \alias{as.data.frame.OptPathDF}
 \title{Convert optimization path to data.frame.}
 \usage{
-\method{as.data.frame}{OptPathDF}(x, row.names = NULL, optional = FALSE,
-  include.x = TRUE, include.y = TRUE, include.rest = TRUE,
-  dob = x$env$dob, eol = x$env$eol, ...)
+\method{as.data.frame}{OptPathDF}(x, row.names = NULL,
+  optional = FALSE, include.x = TRUE, include.y = TRUE,
+  include.rest = TRUE, dob = x$env$dob, eol = x$env$eol, ...)
 }
 \arguments{
 \item{x}{[\code{\link{OptPath}}]\cr

--- a/man/filterParams.Rd
+++ b/man/filterParams.Rd
@@ -6,8 +6,8 @@
 \alias{filterParamsDiscrete}
 \title{Get parameter subset of only certain parameters.}
 \usage{
-filterParams(par.set, ids = NULL, type = NULL, tunable = c(TRUE, FALSE),
-  check.requires = FALSE)
+filterParams(par.set, ids = NULL, type = NULL, tunable = c(TRUE,
+  FALSE), check.requires = FALSE)
 
 filterParamsNumeric(par.set, ids = NULL, tunable = c(TRUE, FALSE),
   include.int = TRUE)

--- a/man/generateDesign.Rd
+++ b/man/generateDesign.Rd
@@ -4,8 +4,8 @@
 \alias{generateDesign}
 \title{Generates a statistical design for a parameter set.}
 \usage{
-generateDesign(n = 10L, par.set, fun, fun.args = list(), trafo = FALSE,
-  augment = 20L)
+generateDesign(n = 10L, par.set, fun, fun.args = list(),
+  trafo = FALSE, augment = 20L)
 }
 \arguments{
 \item{n}{[\code{integer(1)}]\cr

--- a/man/getOptPathBestIndex.Rd
+++ b/man/getOptPathBestIndex.Rd
@@ -64,3 +64,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathCol.Rd
+++ b/man/getOptPathCol.Rd
@@ -44,3 +44,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathCols.Rd
+++ b/man/getOptPathCols.Rd
@@ -47,3 +47,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathDOB.Rd
+++ b/man/getOptPathDOB.Rd
@@ -41,3 +41,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathEOL.Rd
+++ b/man/getOptPathEOL.Rd
@@ -41,3 +41,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathEl.Rd
+++ b/man/getOptPathEl.Rd
@@ -39,3 +39,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathErrorMessages.Rd
+++ b/man/getOptPathErrorMessages.Rd
@@ -40,3 +40,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathExecTimes.Rd
+++ b/man/getOptPathExecTimes.Rd
@@ -40,3 +40,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathLength.Rd
+++ b/man/getOptPathLength.Rd
@@ -31,3 +31,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathParetoFront.Rd
+++ b/man/getOptPathParetoFront.Rd
@@ -61,3 +61,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathX.Rd
+++ b/man/getOptPathX.Rd
@@ -40,3 +40,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{getOptPathY}}, \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/getOptPathY.Rd
+++ b/man/getOptPathY.Rd
@@ -48,3 +48,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{getOptPathX}}, \code{\link{setOptPathElDOB}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/isFeasible.Rd
+++ b/man/isFeasible.Rd
@@ -11,8 +11,9 @@ isFeasible(par, x, use.defaults = FALSE, filter = FALSE)
 Parameter or parameter set.}
 
 \item{x}{[any] \cr
-Single value to check.
-For a parameter set this must be a list.
+Single value to check against the \code{Param} or \code{ParamSet}.
+For a \code{ParamSet} \code{x} must be a list.
+\code{x} has to contain the untransformed values.
 If the list is named, it is possible to only pass a subset of parameters defined
 in the \code{\link{ParamSet}} \code{par}. In that case, only conditions regarding the passed
 parameters are checked.

--- a/man/isRequiresOk.Rd
+++ b/man/isRequiresOk.Rd
@@ -4,7 +4,8 @@
 \alias{isRequiresOk}
 \title{Check if parameter requirements are met.}
 \usage{
-isRequiresOk(par.set, par.vals, ids = names(par.vals), use.defaults = TRUE)
+isRequiresOk(par.set, par.vals, ids = names(par.vals),
+  use.defaults = TRUE)
 }
 \arguments{
 \item{par.set}{[\code{\link{ParamSet}}]\cr

--- a/man/makeParamSet.Rd
+++ b/man/makeParamSet.Rd
@@ -66,8 +66,6 @@ The constructed S3 class is simply a list that contains the element \code{pars}.
 
 If \code{keys} are provided it will automatically be checked whether all expressions within the
 provided parameters only contain arguments that are a subset of keys.
-
-\code{makeNumericParamSet}: Convenience function for numerics.
 }
 \examples{
 makeParamSet(

--- a/man/renderOptPathPlot.Rd
+++ b/man/renderOptPathPlot.Rd
@@ -4,11 +4,12 @@
 \alias{renderOptPathPlot}
 \title{Function for plotting optimization paths.}
 \usage{
-renderOptPathPlot(op, iter, x.over.time, y.over.time, contour.name = NULL,
-  xlim = list(), ylim = list(), alpha = TRUE, log = NULL,
-  colours = c("red", "blue", "green", "orange"), size.points = 3,
-  size.lines = 1.5, impute.scale = 1, impute.value = "missing",
-  scale = "std", ggplot.theme = ggplot2::theme(legend.position = "top"),
+renderOptPathPlot(op, iter, x.over.time, y.over.time,
+  contour.name = NULL, xlim = list(), ylim = list(), alpha = TRUE,
+  log = NULL, colours = c("red", "blue", "green", "orange"),
+  size.points = 3, size.lines = 1.5, impute.scale = 1,
+  impute.value = "missing", scale = "std",
+  ggplot.theme = ggplot2::theme(legend.position = "top"),
   marked = NULL, subset.obs, subset.vars, subset.targets, short.x.names,
   short.y.names, short.rest.names)
 }

--- a/man/sampleValue.Rd
+++ b/man/sampleValue.Rd
@@ -23,6 +23,8 @@ The return type is determined by the type of the parameter. For a set a named li
   of such values in the correct order is returned.
 }
 \description{
+Sample a random value from a parameter or a parameter set uniformly.
+
 Dependent parameters whose requirements are not satisfied are represented by a scalar NA in the output.
 }
 \examples{

--- a/man/sampleValues.Rd
+++ b/man/sampleValues.Rd
@@ -25,6 +25,8 @@ Default is \code{FALSE}.}
 [\code{list}]. For consistency always a list is returned.
 }
 \description{
+Sample n random values from a parameter or a parameter set uniformly.
+
 Dependent parameters whose requirements are not satisfied are represented by a scalar NA in the output.
 }
 \examples{

--- a/man/setOptPathElDOB.Rd
+++ b/man/setOptPathElDOB.Rd
@@ -36,3 +36,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{getOptPathX}}, \code{\link{getOptPathY}},
   \code{\link{setOptPathElEOL}}
 }
+\concept{optpath}

--- a/man/setOptPathElEOL.Rd
+++ b/man/setOptPathElEOL.Rd
@@ -36,3 +36,4 @@ Other optpath: \code{\link{OptPath}},
   \code{\link{getOptPathX}}, \code{\link{getOptPathY}},
   \code{\link{setOptPathElDOB}}
 }
+\concept{optpath}


### PR DESCRIPTION
To enable sampling without replacement.

Currently, sampling with replacement is hardcoded for vector params.

This is needed to sample unique filter methods which are going to be used in ensemble filters.

@jakob-r 	Is this possible in paradox already?

Edit: The fix obv only works for tuneXXX methods that use `sampleValue`. MBO does not. So maybe we need to tackle this in multiple repos..