### PR TITLE
allow default to be a vector to make makeDiscreteVectorParam more similar to makeDiscreteParam

### DIFF
--- a/R/aParam.R
+++ b/R/aParam.R
@@ -124,6 +124,11 @@ makeParam = function(id, type, learner.param, len = 1L, lower = NULL, upper = NU
   } else {
     has.default = TRUE
   }
+  # allow default to be a vector to make makeDiscreteVectorParam more similar to makeDiscreteParam
+  # see https://github.com/berndbischl/ParamHelpers/pull/207
+  if (has.default && type == "discretevector" && !is.list(default)) {
+    default = as.list(default)
+  }
   # FIXME: Do we need to check for NA here? Hopefully not because this might occur in mlr?
   if (has.default && isScalarNA(default))
     warningf("NA used as a default value for learner parameter %s.\nParamHelpers uses NA as a special value for dependent parameters.", id)

--- a/R/isFeasible.R
+++ b/R/isFeasible.R
@@ -129,7 +129,7 @@ constraintsOkParam = function(par, x) {
   else if (type == "discrete")
     inValues(x)
   else if (type == "discretevector")
-    is.list(x) && checkLength(par, x) && all(vlapply(x, inValues))
+    (is.vector(x) || is.list(x)) && checkLength(par, x) && all(vlapply(x, inValues))
   else if (type == "logical")
     is.logical(x) && length(x) == 1 && !is.na(x)
   else if (type == "logicalvector")

--- a/tests/testthat/test_Param.R
+++ b/tests/testthat/test_Param.R
@@ -28,6 +28,9 @@ test_that("num param", {
   expect_equal(p$values, NULL)
 
   # defaults
+  p = makeNumericParam(id = "x", default = 5)
+  expect_equal(p$default, 5)
+
   p = makeNumericParam(id = "x", allow.inf = TRUE, default = Inf)
   expect_error(makeNumericParam(id = "x", allow.inf = FALSE, default = Inf), "feasible")
 
@@ -67,6 +70,13 @@ test_that("num vec param", {
   expect_true(!isFeasible(p, NULL))
   expect_true(isFeasible(p, -Inf))
 
+  # defaults
+  p = makeNumericVectorParam(id = "x", default = c(4,3,2), len = 3)
+  expect_equal(p$default, c(4,3,2))
+  expect_error(makeNumericVectorParam(id = "x", default = 1, len = 3), "feasible")
+  p = makeNumericVectorParam(id = "x", allow.inf = TRUE, default = c(Inf, 2), len = 2)
+  expect_error(makeNumericVectorParam(id = "x", allow.inf = FALSE, default = c(Inf, 2), len = 2), "feasible")
+
   ## Error conditions:
   expect_error(makeNumericVectorParam(id = "x", lower = "bam", upper = 1))
   expect_error(makeNumericVectorParam(id = "x", len = 2, lower = NA, upper = 1))
@@ -101,6 +111,10 @@ test_that("int param", {
   expect_true(!isFeasible(p, -2L))
   expect_true(!isFeasible(p, -Inf))
   expect_true(!isFeasible(p, NULL))
+
+  # defaults
+  p = makeIntegerParam(id = "x", default = 5L)
+  expect_equal(p$default, 5L)
 
   ## Error conditions:
   expect_error(makeIntegerParam(id = "x", lower = "bam", upper = 1L))
@@ -137,6 +151,11 @@ test_that("int vec param", {
   expect_true(!isFeasible(p, c(-Inf, 1)))
   expect_true(!isFeasible(p, NULL))
 
+  # defaults
+  p = makeIntegerVectorParam(id = "x", default = c(4L,3L,2L), len = 3)
+  expect_equal(p$default, c(4L,3L,2L))
+  expect_error(makeIntegerVectorParam(id = "x", default = 1L, len = 3L), "feasible")
+
   ## Error conditions:
   expect_error(makeIntegerVectorParam(id = "x", lower = "bam", upper = 1))
   expect_error(makeIntegerVectorParam(id = "x", len = 2, lower = NA, upper = 1))
@@ -171,6 +190,10 @@ test_that("discrete param", {
   expect_equal(p$lower, NULL)
   expect_equal(p$upper, NULL)
 
+  # defaults
+  p = makeDiscreteParam(id = "x", default = "zeb", values = list("zeb", "ra", 45, 22))
+  expect_equal(p$default, "zeb")
+
   ## Error conditions:
   expect_error(makeDiscreteParam(id = "x", values = list(a = 1, "a")), "names could not be guessed")
   expect_error(makeDiscreteParam(id = "x", values = list()), "No possible value")
@@ -192,6 +215,16 @@ test_that("discrete vec param", {
   expect_equal(p$lower, NULL)
   expect_equal(p$upper, NULL)
 
+  # defaults
+  p = makeDiscreteVectorParam(id = "x", default = c("zeb", "ra"), values = list("zeb", "ra", 45, 22), len = 2)
+  expect_equal(unlist(unname(p$default)), c("zeb", "ra"))
+
+  p = makeDiscreteVectorParam(id = "x", default = "zeb", values = list("zeb", "ra", 45, 22), len = 1)
+  expect_equal(unlist(unname(p$default)), "zeb")
+
+  expect_error(makeDiscreteVectorParam(id = "x", default = "zeb", values = list("zeb", "ra", 45, 22), len = 3L), "feasible")
+  expect_error(makeDiscreteVectorParam(id = "x", default = "34567", values = list("zeb", "ra", 45, 22), len = 3L), "feasible")
+
   ## Error conditions:
   expect_error(makeDiscreteVectorParam(id = "x", len = 2, values = list(a = 1, "a")), "names could not be guessed")
   expect_error(makeDiscreteVectorParam(id = "x", len = 2, values = list()), "No possible value")
@@ -209,6 +242,10 @@ test_that("logic param", {
   expect_true(!isFeasible(p, 1L))
   expect_true(!isFeasible(p, 1))
   expect_true(!isFeasible(p, NULL))
+
+  # defaults
+  p = makeLogicalParam(id = "x", default = TRUE)
+  expect_equal(p$default, TRUE)
 })
 
 test_that("logic vec param", {
@@ -221,6 +258,12 @@ test_that("logic vec param", {
   expect_true(!isFeasible(p, TRUE))
   expect_true(!isFeasible(p, FALSE))
   expect_true(!isFeasible(p, NULL))
+
+  # defaults
+  p = makeLogicalVectorParam(id = "x", default = c(TRUE, FALSE, TRUE), len = 3)
+  expect_equal(p$default, c(TRUE, FALSE, TRUE))
+
+  expect_error(makeLogicalVectorParam(id = "x", default = c(TRUE), len = 3L), "feasible")
 })
 
 test_that("character param", {


### PR DESCRIPTION
Hello everyone (or whoever it may concern),

I ran into a problem earlier today with `makeDiscreteVectorParam()`. I wrote some tests for it. 
It turns out I was using the function wrong, but I believe the suggested changes would be of added value regardless.

## Example
I can create a numeric vector parameter with a default setting:
```r
makeNumericVectorParam(id = "x", lower = 1, upper = 100, default = c(1,2), len = 2)
```
```
           Type len Def   Constr Req Tunable Trafo
1 numericvector   2 1,2 1 to 100   -    TRUE     -
```

I can create a discrete parameter with a default setting:
```r
makeDiscreteParam(id = "x", values = letters, default = letters[1])
```
```
      Type len Def                                   Constr Req Tunable Trafo
1 discrete   -   a a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s...   -    TRUE     -
```

However, I cannot make a discrete vector parameter with a default setting:
```r
makeDiscreteVectorParam(id = "x", values = letters, default = letters[1:2], len = 2)
```
```
Error in makeParam(id = id, type = "discretevector", learner.param = FALSE,  : 
  x : 'default' must be a feasible parameter setting.
```

## Proposed solution
I added a few lines of code to the unit test to test this edge case.
The error does not occur when the default is set to `default = as.list(letters[1:2])`. 
However, since `values` is allowed to be a vector instead of a list, `default`
should also be allowed to be a vector. 

I solved the problem by making `isFeasible()` (actually `constraintsOkParam()`) a bit
less strict, by changing `is.list(x)` into `is.list(x) || is.vector(x)`.

## Downstream packages?
If this change could create a problem for downstream packages (since `default` could now be a vector instead of a list), you could also add the following lines to `makeParam()`:
```r
if (type == "discretevector") {
  default = as.list(default)
}
```

