### PR TITLE
add trafo parameter for discretevector

### DIFF
--- a/R/ParamSet.R
+++ b/R/ParamSet.R
@@ -43,6 +43,11 @@
 #'   makeIntegerParam("v", lower = expression(floor(n)), upper = 2),
 #'   keys = c("p", "n")
 #' )
+#' makeParamSet(
+#'   makeNumericParam("min", lower = 0, upper = 0.8),
+#'   makeNumericParam("max", lower = 0.2, upper = 1),
+#'   forbidden = expression(min > max)
+#' )
 makeParamSet = function(..., params = NULL, forbidden = NULL, keys = NULL) {
   pars = list(...)
   if (length(pars) > 0 && !is.null(params))

--- a/R/makeParamFuns.R
+++ b/R/makeParamFuns.R
@@ -66,12 +66,12 @@ makeDiscreteParam = function(id, values, trafo = NULL, default,
 
 #' @rdname Param
 #' @export
-makeDiscreteVectorParam = function(id, len, values, default, requires = NULL,
+makeDiscreteVectorParam = function(id, len, values, trafo = NULL, default, requires = NULL,
   tunable = TRUE, special.vals = list()) {
 
   makeParam(id = id, type = "discretevector", learner.param = FALSE, len = len,
     values = values, default = default,
-    trafo = NULL, requires = requires, tunable = tunable, special.vals = special.vals)
+    trafo = trafo, requires = requires, tunable = tunable, special.vals = special.vals)
 }
 
 #' @rdname Param

--- a/man/Param.Rd
+++ b/man/Param.Rd
@@ -41,8 +41,8 @@ makeLogicalVectorParam(id, len, cnames = NULL, default,
 makeDiscreteParam(id, values, trafo = NULL, default, requires = NULL,
   tunable = TRUE, special.vals = list())
 
-makeDiscreteVectorParam(id, len, values, default, requires = NULL,
-  tunable = TRUE, special.vals = list())
+makeDiscreteVectorParam(id, len, values, trafo = NULL, default,
+  requires = NULL, tunable = TRUE, special.vals = list())
 
 makeFunctionParam(id, default = default, requires = NULL,
   special.vals = list())

--- a/man/makeParamSet.Rd
+++ b/man/makeParamSet.Rd
@@ -80,4 +80,9 @@ makeParamSet(
   makeIntegerParam("v", lower = expression(floor(n)), upper = 2),
   keys = c("p", "n")
 )
+makeParamSet(
+  makeNumericParam("min", lower = 0, upper = 0.8),
+  makeNumericParam("max", lower = 0.2, upper = 1),
+  forbidden = expression(min > max)
+)
 }

--- a/tests/testthat/test_ParamSet.R
+++ b/tests/testthat/test_ParamSet.R
@@ -132,6 +132,11 @@ test_that("makeNumericParamset", {
   expect_equal(getParamLengths(ps), c(x = 2))
   expect_equal(getLower(ps), c(x = 10, x = 10))
   expect_equal(getUpper(ps), c(x = Inf, x = Inf))
+  ps = makeNumericParamSet(upper = 10, len = 2, vector = TRUE)
+  expect_equal(getParamIds(ps), "x")
+  expect_equal(getParamLengths(ps), c(x = 2))
+  expect_equal(getLower(ps), c(x = -Inf, x = -Inf))
+  expect_equal(getUpper(ps), c(x = 10, x = 10))
   ps = makeNumericParamSet(id = "y", upper = 3, len = 2, vector = FALSE)
   expect_equal(getParamIds(ps), c("y1", "y2"))
   expect_equal(getParamLengths(ps), c(y1 = 1, y2 = 1))
@@ -187,6 +192,13 @@ test_that("print works", {
     makeNumericVectorLearnerParam(id = "v", default = 1:2, len = 2L)
   )
   expect_output(print(ps, trafo = FALSE, used = FALSE), "numericvector")
+
+  ps = makeParamSet(
+    makeIntegerLearnerParam(id = "x", default = 50L, lower = 1L),
+    makeNumericVectorLearnerParam(id = "v", default = 1:2, len = 2L),
+    forbidden = expression(x < v[[1]])
+  )
+  expect_output(print(ps), "Forbidden region specified")
 })
 
 test_that("expressions get converted", {
@@ -205,4 +217,18 @@ test_that("expressions get converted", {
       makeLogicalLearnerParam("a", default = FALSE),
       makeLogicalLearnerParam("b", default = FALSE, requires = "a == TRUE")
     )}, "call")
+})
+
+test_that("test whether paramset fails gracefully", {
+  li <- list(
+    makeLogicalLearnerParam("a", default = FALSE),
+    makeLogicalLearnerParam("b", default = FALSE, requires = expression(a == TRUE))
+  )
+  expect_error({
+    makeParamSet(
+      makeLogicalLearnerParam("a", default = FALSE),
+      makeLogicalLearnerParam("b", default = FALSE, requires = quote(a == TRUE)),
+      params = li
+    )
+  }, regexp = "You can only use one of \\.\\.\\. or params!")
 })

--- a/tests/testthat/test_trafo.R
+++ b/tests/testthat/test_trafo.R
@@ -10,13 +10,14 @@ test_that("trafoValue with param set", {
   ps = makeParamSet(
     makeIntegerParam("u", trafo=function(x) 2*x),
     makeNumericVectorParam("v", len=2, trafo=function(x) x/sum(x)),
-    makeDiscreteParam("w", values=c("a", "b"))
+    makeDiscreteParam("w", values=c("a", "b"), trafo=function(x) paste0("=", x, "=")),
+    makeDiscreteVectorParam("x", values=letters, len=3, trafo=sort)
   )
-  expect_equal(trafoValue(ps, list(3, c(2, 4), "a")), list(u=6, v=c(2/6, 4/6), w="a"))
+  expect_equal(trafoValue(ps, list(3, c(2, 4), "a", c("b", "a", "c"))), list(u=6, v=c(2/6, 4/6), w="=a=", x=c("a", "b", "c")))
   # check if error is thrown when list has different names
-  expect_error(trafoValue(ps, list(a=1, b=1, c="b")))
+  expect_error(trafoValue(ps, list(a=1, b=1, c="b", d=c("a", "b", "c"))))
   # check if trafo function is applied on correct list-slots
-  expect_equal(trafoValue(ps, list(w="b", v=1:2, u=1)), list(u = 2*1, v = 1:2/sum(1:2), w="b"))
+  expect_equal(trafoValue(ps, list(w="b", v=1:2, u=1, x=c("x", "f", "p"))), list(u = 2*1, v = 1:2/sum(1:2), w="=b=", x = c("f", "p", "x")))
 })
 
 


### PR DESCRIPTION
Would it be possible to add the trafo function for the discretevectorparam?

[Edit: the proposed changes happened in commit 92da645ff10dd2a0933f2241c6e6dc454c79cfe7. The other commits are small improvements to unit tests and documentation and might cause confusion when looking at "Files changed".]

It's absolutely vital for a [function](https://github.com/dynverse/dynparam/blob/master/R/param_subset.R#L49-L56) in a package I wish to upload to CRAN. 

I ran a R CMD check and a revdepcheck, and they both showed that this change would not break any downstream packages.

### R CMD check
```
── R CMD check results ──────────── ParamHelpers 1.13 ────
Duration: 3m 2.6s

0 errors ✔ | 0 warnings ✔ | 0 notes ✔

R CMD check succeeded
```

### revdepcheck
```
── CHECK ────────────────────────────────── 16 packages ──
✔ CEGO 2.3.0                             ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ CEGO 2.3.0                             ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ llama 0.9.2                            ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ aslib 0.1                              ── E: 1     | W: 0     | N: 0                                                                                                                                            
✔ metagen 1.0                            ── E: 1     | W: 0     | N: 0                                                                                                                                            
✔ cmaesr 1.0.3                           ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ ecr 2.1.0                              ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ flacco 1.7                             ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ OpenML 1.8                             ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ bnclassify 0.4.2                       ── E: 0     | W: 2     | N: 3                                                                                                                                            
✔ randomsearch 0.2.0                     ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ mlrCPO 0.3.4-2                         ── E: 0     | W: 0     | N: 1                                                                                                                                            
✔ SIAMCAT 1.0.0                          ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ smoof 1.5.1                            ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ tuneRanger 0.4                         ── E: 0     | W: 0     | N: 0                                                                                                                                            
✔ mlrMBO 1.1.2                           ── E: 0     | W: 0     | N: 1                                                                                                                                            
✔ mlr 2.13                               ── E: 0     | W: 0     | N: 2                                                                                                                                            
OK:                                                                                                                                                                                                             
BROKEN: 0
Total time: 49 min
```